### PR TITLE
fix: pass spawn as shell, fix #184 

### DIFF
--- a/scripts/db.ts
+++ b/scripts/db.ts
@@ -19,6 +19,7 @@ import { initLogger, useLogger } from '../packages/common/src/helper/logger'
         DATABASE_DSN: dsn,
       },
       stdio: 'pipe',
+      shell: true,
     })
 
     child.stdout.on('data', (data) => {


### PR DESCRIPTION
This fix #184

我也不知道为什么，但spawn pnpm drizzle-kit用shell运行就能用