### PR TITLE
fix: emoji placeholder split for chat has no avatar

### DIFF
--- a/apps/frontend/src/components/ui/Avatar.vue
+++ b/apps/frontend/src/components/ui/Avatar.vue
@@ -21,15 +21,16 @@ const sizeMap = {
 
 const avatarSize = computed(() => sizeMap[props.size])
 
+const segmenter = new Intl.Segmenter('zh-CN', {granularity: 'grapheme'});
+
 const initials = computed(() => {
   if (!props.name)
     return ''
-  return props.name
-    .split(' ')
-    .map(word => word[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 1)
+  let segment = segmenter.segment(props.name)[Symbol.iterator]().next().value;
+  if (segment) {
+    return segment.segment.toUpperCase()
+  }
+  return ''
 })
 
 const backgroundColor = computed(() => {


### PR DESCRIPTION
在UTF-16中，有些字元的Unicode码元需要超过一个char的长度来存储（即UTF-16代理对），一部分emoji就是如此（😺、🐺），甚至还有使用零宽连字符（\u200D）来组合多个emoji的（🏳️‍⚧️、👩‍🦳），使用`split('')`并取第一个char的方式无法处理此类情况

Before:  
![image](https://github.com/user-attachments/assets/7f28db56-6956-4d5d-bd73-9d2a27a69a04)

After:  
![image](https://github.com/user-attachments/assets/a6505c76-8e84-4fc7-9792-e92d841022ef)

