### PR TITLE
Add rate limiting to OpenAI API requests

### DIFF
--- a/packages/core/src/utils/embed.ts
+++ b/packages/core/src/utils/embed.ts
@@ -4,6 +4,7 @@ import { EmbeddingProvider } from '@tg-search/common'
 import { useConfig } from '@tg-search/common/composable'
 import { createOllama } from '@xsai-ext/providers-local'
 import { embedMany } from '@xsai/embed'
+import { withOpenAIRateLimit } from './openai-rate-limit'
 
 import { Ok } from './monad'
 
@@ -13,12 +14,14 @@ export async function embedContents(contents: string[]) {
   let embeddings: EmbedManyResult
   switch (embeddingConfig.provider) {
     case EmbeddingProvider.OPENAI:
-      embeddings = await embedMany({
-        apiKey: embeddingConfig.apiKey,
-        baseURL: embeddingConfig.apiBase || '',
-        input: contents,
-        model: embeddingConfig.model,
-      })
+      embeddings = await withOpenAIRateLimit(() =>
+        embedMany({
+          apiKey: embeddingConfig.apiKey,
+          baseURL: embeddingConfig.apiBase || '',
+          input: contents,
+          model: embeddingConfig.model,
+        }),
+      )
       break
     case EmbeddingProvider.OLLAMA: {
       const ollama = createOllama()

--- a/packages/core/src/utils/embed.ts
+++ b/packages/core/src/utils/embed.ts
@@ -4,9 +4,9 @@ import { EmbeddingProvider } from '@tg-search/common'
 import { useConfig } from '@tg-search/common/composable'
 import { createOllama } from '@xsai-ext/providers-local'
 import { embedMany } from '@xsai/embed'
-import { withOpenAIRateLimit } from './openai-rate-limit'
 
 import { Ok } from './monad'
+import { withOpenAIRateLimit } from './openai-rate-limit'
 
 export async function embedContents(contents: string[]) {
   const embeddingConfig = useConfig().api.embedding

--- a/packages/core/src/utils/openai-rate-limit.ts
+++ b/packages/core/src/utils/openai-rate-limit.ts
@@ -1,0 +1,12 @@
+let lastOpenAIRequestTime = 0;
+const OPENAI_RATE_LIMIT_MS = 1500; // 1.5 seconds
+
+export async function withOpenAIRateLimit<T>(fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const wait = Math.max(0, lastOpenAIRequestTime + OPENAI_RATE_LIMIT_MS - now);
+  if (wait > 0) {
+    await new Promise(res => setTimeout(res, wait));
+  }
+  lastOpenAIRequestTime = Date.now();
+  return fn();
+}

--- a/packages/core/src/utils/openai-rate-limit.ts
+++ b/packages/core/src/utils/openai-rate-limit.ts
@@ -1,12 +1,13 @@
-let lastOpenAIRequestTime = 0;
-const OPENAI_RATE_LIMIT_MS = 1500; // 1.5 seconds
+let lastOpenAIRequestTime = 0
+const OPENAI_RATE_LIMIT_MS = 1500 // 1.5 seconds
 
 export async function withOpenAIRateLimit<T>(fn: () => Promise<T>): Promise<T> {
-  const now = Date.now();
-  const wait = Math.max(0, lastOpenAIRequestTime + OPENAI_RATE_LIMIT_MS - now);
+  const now = Date.now()
+  const wait = Math.max(0, lastOpenAIRequestTime + OPENAI_RATE_LIMIT_MS - now)
   if (wait > 0) {
-    await new Promise(res => setTimeout(res, wait));
+    await new Promise(res => setTimeout(res, wait))
   }
-  lastOpenAIRequestTime = Date.now();
-  return fn();
+
+  lastOpenAIRequestTime = Date.now()
+  return fn()
 }


### PR DESCRIPTION
给 OpenAI API 请求增加速率限制。部分使用 Openai 协议的 API 有速率限制要求

代码 **并不完善且未经完整测试，本人无意继续完善修改**

另外如接受 PR 请编辑代码，新增相关配置项，如 OPENAI_RATE_LIMIT_MS 。