### PR TITLE
refactor(core): use `uuid` instead of randomUUID of `node:crypto`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "pathe": "^2.0.3",
     "postgres": "^3.4.7",
     "telegram": "^2.26.22",
+    "uuid": "^11.1.0",
     "valibot": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/core/src/utils/message.ts
+++ b/packages/core/src/utils/message.ts
@@ -2,11 +2,10 @@ import type { Result } from '@unbird/result'
 
 import type { CoreMessageMediaFromServer } from './media'
 
-import { randomUUID } from 'node:crypto'
-
 import { Err, Ok } from '@unbird/result'
 import bigInt from 'big-integer'
 import { Api } from 'telegram'
+import { v4 as randomUUID } from 'uuid'
 
 import { parseMediaId, parseMediaType } from './media'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,19 +72,19 @@ importers:
         version: 5.9.2
       unocss:
         specifier: ^66.4.2
-        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       unocss-preset-animations:
         specifier: ^1.2.1
-        version: 1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)))
+        version: 1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)))
       unocss-preset-shadcn:
         specifier: ^0.5.0
-        version: 0.5.0(unocss-preset-animations@1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))))(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)))
+        version: 0.5.0(unocss-preset-animations@1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))))(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)))
       unplugin-unused:
         specifier: ^0.5.1
         version: 0.5.1
       vite:
         specifier: npm:rolldown-vite@latest
-        version: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+        version: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)
@@ -178,7 +178,7 @@ importers:
         version: 66.4.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 6.0.1(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/volar':
         specifier: ^3.0.0-beta.21
         version: 3.0.0-beta.21(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
@@ -190,28 +190,28 @@ importers:
         version: 26.0.12(electron-builder-squirrel-windows@26.0.12)
       electron-vite:
         specifier: ^4.0.0
-        version: 4.0.0(patch_hash=30174b0e57be3bb1231838b8d1c609fbad9f2c190bb02f96183ba1b8991d4dba)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 4.0.0(patch_hash=30174b0e57be3bb1231838b8d1c609fbad9f2c190bb02f96183ba1b8991d4dba)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
       unocss:
         specifier: ^66.4.2
-        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       unplugin-vue-macros:
         specifier: ^2.14.5
-        version: 2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
+        version: 2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
       unplugin-vue-router:
         specifier: ^0.15.0
         version: 0.15.0(@vue/compiler-sfc@3.5.18)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vite-plugin-inspect:
         specifier: ^11.3.2
-        version: 11.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 11.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       vite-plugin-vue-devtools:
         specifier: ^8.0.0
-        version: 8.0.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 8.0.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        version: 0.11.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vue-tsc:
         specifier: ^3.0.5
         version: 3.0.5(typescript@5.9.2)
@@ -287,28 +287,28 @@ importers:
         version: 66.4.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 6.0.1(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/volar':
         specifier: ^3.0.0-beta.21
         version: 3.0.0-beta.21(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
       unocss:
         specifier: ^66.4.2
-        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       unplugin-vue-macros:
         specifier: ^2.14.5
-        version: 2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
+        version: 2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
       unplugin-vue-router:
         specifier: ^0.15.0
         version: 0.15.0(@vue/compiler-sfc@3.5.18)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vite-plugin-inspect:
         specifier: ^11.3.2
-        version: 11.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 11.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       vite-plugin-vue-devtools:
         specifier: ^8.0.0
-        version: 8.0.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 8.0.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        version: 0.11.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vue-tsc:
         specifier: ^3.0.5
         version: 3.0.5(typescript@5.9.2)
@@ -342,7 +342,7 @@ importers:
     devDependencies:
       '@proj-airi/unplugin-drizzle-orm-migrations':
         specifier: ^0.1.2
-        version: 0.1.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 0.1.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
 
   packages/client:
     dependencies:
@@ -467,13 +467,16 @@ importers:
       telegram:
         specifier: ^2.26.22
         version: 2.26.22
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.9.2)
     devDependencies:
       '@proj-airi/unplugin-drizzle-orm-migrations':
         specifier: ^0.1.2
-        version: 0.1.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 0.1.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       '@types/pg':
         specifier: ^8.15.5
         version: 8.15.5
@@ -552,31 +555,31 @@ importers:
         version: 66.4.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 6.0.1(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/volar':
         specifier: ^3.0.0-beta.21
         version: 3.0.0-beta.21(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
       unocss:
         specifier: ^66.4.2
-        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       unplugin-vue-components:
         specifier: ^29.0.0
         version: 29.0.0(@babel/parser@7.28.0)(vue@3.5.18(typescript@5.9.2))
       unplugin-vue-macros:
         specifier: ^2.14.5
-        version: 2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
+        version: 2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
       unplugin-vue-router:
         specifier: ^0.15.0
         version: 0.15.0(@vue/compiler-sfc@3.5.18)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vite-plugin-inspect:
         specifier: ^11.3.2
-        version: 11.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+        version: 11.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       vite-plugin-vue-devtools:
         specifier: ^8.0.0
-        version: 8.0.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 8.0.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        version: 0.11.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vue-tsc:
         specifier: ^3.0.5
         version: 3.0.5(typescript@5.9.2)
@@ -3759,6 +3762,15 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -5149,8 +5161,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown-vite@7.1.3:
-    resolution: {integrity: sha512-J22JlCJQbIRxR6KGwpf76Uq3R4wk6avQHCijXGPsXsbVpPt+Uavg5M5dvzP7XdlAKL8uZE5Xof9j4Y9yu+cxxg==}
+  rolldown-vite@7.1.4:
+    resolution: {integrity: sha512-VE0cXhJfTypUhm71w4pR62dMyqw8JKHWMdbUBSDVqZTGGpZz5Zkw+cT47rvBR/SQ9E9F2GtlW02rWIY2T9HdLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -7064,13 +7076,13 @@ snapshots:
 
   '@proj-airi/unocss-preset-chromatic@1.0.0': {}
 
-  '@proj-airi/unplugin-drizzle-orm-migrations@0.1.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))':
+  '@proj-airi/unplugin-drizzle-orm-migrations@0.1.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))':
     dependencies:
       c12: 3.2.0
       uncrypto: 0.1.3
       unplugin: 2.3.5
     optionalDependencies:
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
 
@@ -7567,13 +7579,13 @@ snapshots:
 
   '@unbird/result@1.1.0': {}
 
-  '@unocss/astro@66.4.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))':
+  '@unocss/astro@66.4.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))':
     dependencies:
       '@unocss/core': 66.4.2
       '@unocss/reset': 66.4.2
-      '@unocss/vite': 66.4.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      '@unocss/vite': 66.4.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
     optionalDependencies:
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
 
   '@unocss/cli@66.4.2':
     dependencies:
@@ -7725,7 +7737,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.4.2
 
-  '@unocss/vite@66.4.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))':
+  '@unocss/vite@66.4.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.4.2
@@ -7736,12 +7748,12 @@ snapshots:
       pathe: 2.0.3
       tinyglobby: 0.2.14
       unplugin-utils: 0.2.4
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
 
-  '@vitejs/plugin-vue@6.0.1(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
       vue: 3.5.18(typescript@5.9.2)
 
   '@vitest/eslint-plugin@1.3.4(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1))':
@@ -7947,12 +7959,12 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/devtools@0.4.1(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(typescript@5.9.2)':
+  '@vue-macros/devtools@0.4.1(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(typescript@5.9.2)':
     dependencies:
       sirv: 3.0.1
       vue: 3.5.18(typescript@5.9.2)
     optionalDependencies:
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - typescript
 
@@ -8175,14 +8187,14 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.7
 
-  '@vue/devtools-core@8.0.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@vue/devtools-core@8.0.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
     dependencies:
       '@vue/devtools-kit': 8.0.0
       '@vue/devtools-shared': 8.0.0
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      vite-hot-client: 2.1.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       vue: 3.5.18(typescript@5.9.2)
     transitivePeerDependencies:
       - vite
@@ -9041,7 +9053,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@4.0.0(patch_hash=30174b0e57be3bb1231838b8d1c609fbad9f2c190bb02f96183ba1b8991d4dba)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
+  electron-vite@4.0.0(patch_hash=30174b0e57be3bb1231838b8d1c609fbad9f2c190bb02f96183ba1b8991d4dba)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.0)
@@ -9049,7 +9061,7 @@ snapshots:
       esbuild: 0.25.6
       magic-string: 0.30.17
       picocolors: 1.1.1
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9585,6 +9597,10 @@ snapshots:
       pend: 1.2.0
 
   fdir@6.4.6(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
@@ -11141,9 +11157,9 @@ snapshots:
       - oxc-resolver
       - supports-color
 
-  rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1):
+  rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1):
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       lightningcss: 1.30.1
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -11620,20 +11636,20 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss-preset-animations@1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))):
+  unocss-preset-animations@1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))):
     dependencies:
-      unocss: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      unocss: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
     optionalDependencies:
       '@unocss/preset-wind3': 66.4.2
 
-  unocss-preset-shadcn@0.5.0(unocss-preset-animations@1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))))(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))):
+  unocss-preset-shadcn@0.5.0(unocss-preset-animations@1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))))(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))):
     dependencies:
-      unocss: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
-      unocss-preset-animations: 1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)))
+      unocss: 66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      unocss-preset-animations: 1.2.1(@unocss/preset-wind3@66.4.2)(unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)))
 
-  unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
+  unocss@66.4.2(postcss@8.5.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
-      '@unocss/astro': 66.4.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      '@unocss/astro': 66.4.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
       '@unocss/cli': 66.4.2
       '@unocss/core': 66.4.2
       '@unocss/postcss': 66.4.2(postcss@8.5.6)
@@ -11651,19 +11667,19 @@ snapshots:
       '@unocss/transformer-compile-class': 66.4.2
       '@unocss/transformer-directives': 66.4.2
       '@unocss/transformer-variant-group': 66.4.2
-      '@unocss/vite': 66.4.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      '@unocss/vite': 66.4.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
     optionalDependencies:
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - postcss
       - supports-color
 
-  unplugin-combine@1.2.1(esbuild@0.25.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(unplugin@1.16.1):
+  unplugin-combine@1.2.1(esbuild@0.25.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(unplugin@1.16.1):
     optionalDependencies:
       esbuild: 0.25.6
       rollup: 4.45.0
       unplugin: 1.16.1
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
 
   unplugin-unused@0.5.1:
     dependencies:
@@ -11701,7 +11717,7 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  unplugin-vue-macros@2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2)):
+  unplugin-vue-macros@2.14.5(@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2)))(esbuild@0.25.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2)):
     dependencies:
       '@vue-macros/better-define': 1.11.4(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/boolean-prop': 0.5.5(vue@3.5.18(typescript@5.9.2))
@@ -11716,7 +11732,7 @@ snapshots:
       '@vue-macros/define-render': 1.6.6(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/define-slots': 1.2.6(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/define-stylex': 0.2.3(vue@3.5.18(typescript@5.9.2))
-      '@vue-macros/devtools': 0.4.1(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(typescript@5.9.2)
+      '@vue-macros/devtools': 0.4.1(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(typescript@5.9.2)
       '@vue-macros/export-expose': 0.3.5(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/export-props': 0.6.5(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/export-render': 0.3.5(vue@3.5.18(typescript@5.9.2))
@@ -11733,7 +11749,7 @@ snapshots:
       '@vue-macros/short-vmodel': 1.5.5(vue@3.5.18(typescript@5.9.2))
       '@vue-macros/volar': 0.30.15(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
       unplugin: 1.16.1
-      unplugin-combine: 1.2.1(esbuild@0.25.6)(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(unplugin@1.16.1)
+      unplugin-combine: 1.2.1(esbuild@0.25.6)(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(rollup@4.45.0)(unplugin@1.16.1)
       unplugin-vue-define-options: 1.5.5(vue@3.5.18(typescript@5.9.2))
       vue: 3.5.18(typescript@5.9.2)
     transitivePeerDependencies:
@@ -11822,15 +11838,15 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-dev-rpc@1.1.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
+  vite-dev-rpc@1.1.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
       birpc: 2.5.0
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
-      vite-hot-client: 2.1.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite-hot-client: 2.1.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
 
-  vite-hot-client@2.1.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
+  vite-hot-client@2.1.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
 
   vite-node@3.2.4(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1):
     dependencies:
@@ -11853,7 +11869,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@11.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
+  vite-plugin-inspect@11.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
       ansis: 4.1.0
       debug: 4.4.1
@@ -11863,27 +11879,27 @@ snapshots:
       perfect-debounce: 1.0.0
       sirv: 3.0.1
       unplugin-utils: 0.2.4
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
-      vite-dev-rpc: 1.1.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite-dev-rpc: 1.1.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.0.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2)):
+  vite-plugin-vue-devtools@8.0.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2)):
     dependencies:
-      '@vue/devtools-core': 8.0.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@vue/devtools-core': 8.0.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
       '@vue/devtools-kit': 8.0.0
       '@vue/devtools-shared': 8.0.0
       execa: 9.6.0
       sirv: 3.0.1
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
-      vite-plugin-inspect: 11.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
-      vite-plugin-vue-inspector: 5.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite-plugin-inspect: 11.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
+      vite-plugin-vue-inspector: 5.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.2(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
+  vite-plugin-vue-inspector@5.3.2(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.0)
@@ -11894,15 +11910,15 @@ snapshots:
       '@vue/compiler-dom': 3.5.18
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-layouts@0.11.0(rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2)):
+  vite-plugin-vue-layouts@0.11.0(rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2)):
     dependencies:
       debug: 4.4.1
       fast-glob: 3.3.3
-      vite: rolldown-vite@7.1.3(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
+      vite: rolldown-vite@7.1.4(@types/node@24.2.1)(esbuild@0.25.6)(jiti@2.5.1)(tsx@4.20.4)(yaml@2.8.1)
       vue: 3.5.18(typescript@5.9.2)
       vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
     transitivePeerDependencies:


### PR DESCRIPTION
The performance of [uuid v4](https://www.npmjs.com/package/uuid#uuidv4options-buffer-offset) is consistent with node:crypto's randomUUID