### PR TITLE
feat(search): go to selected message

### DIFF
--- a/packages/client/src/event-handlers/storage.ts
+++ b/packages/client/src/event-handlers/storage.ts
@@ -15,6 +15,6 @@ export function registerStorageEventHandlers(
   })
 
   // Wait for result event
-  registerEventHandler('storage:search:messages:data', ({ messages: _messages }) => {})
-  registerEventHandler('storage:messages:context', ({ chatId: _chatId, messageId: _messageId, messages: _messages }) => {})
+  registerEventHandler('storage:search:messages:data', (_) => {})
+  registerEventHandler('storage:messages:context', (_) => {})
 }

--- a/packages/client/src/event-handlers/storage.ts
+++ b/packages/client/src/event-handlers/storage.ts
@@ -16,4 +16,5 @@ export function registerStorageEventHandlers(
 
   // Wait for result event
   registerEventHandler('storage:search:messages:data', ({ messages: _messages }) => {})
+  registerEventHandler('storage:messages:context', ({ chatId: _chatId, messageId: _messageId, messages: _messages }) => {})
 }

--- a/packages/core/src/event-handlers/storage.ts
+++ b/packages/core/src/event-handlers/storage.ts
@@ -4,7 +4,7 @@ import type { CoreDialog } from '../services'
 
 import { useLogger } from '@unbird/logg'
 
-import { convertToCoreRetrievalMessages, fetchChats, fetchMessagesWithPhotos, getChatMessagesStats, recordChats, recordMessagesWithMedia, retrieveMessages } from '../models'
+import { convertToCoreRetrievalMessages, fetchChats, fetchMessageContextWithPhotos, fetchMessagesWithPhotos, getChatMessagesStats, recordChats, recordMessagesWithMedia, retrieveMessages } from '../models'
 import { embedContents } from '../utils/embed'
 
 export function registerStorageEventHandlers(ctx: CoreContext) {
@@ -15,6 +15,21 @@ export function registerStorageEventHandlers(ctx: CoreContext) {
     logger.withFields({ chatId, pagination }).verbose('Fetching messages')
     const messages = (await fetchMessagesWithPhotos(chatId, pagination)).unwrap()
     emitter.emit('storage:messages', { messages })
+  })
+
+  emitter.on('storage:fetch:message-context', async ({ chatId, messageId, before = 20, after = 20 }) => {
+    const safeBefore = Math.max(0, before)
+    const safeAfter = Math.max(0, after)
+
+    logger.withFields({ chatId, messageId, before: safeBefore, after: safeAfter }).verbose('Fetching message context')
+
+    const messages = (await fetchMessageContextWithPhotos(chatId, messageId, safeBefore, safeAfter)).unwrap()
+
+    emitter.emit('storage:messages:context', {
+      chatId,
+      messageId,
+      messages,
+    })
   })
 
   emitter.on('storage:record:messages', async ({ messages }) => {

--- a/packages/core/src/event-handlers/storage.ts
+++ b/packages/core/src/event-handlers/storage.ts
@@ -23,13 +23,9 @@ export function registerStorageEventHandlers(ctx: CoreContext) {
 
     logger.withFields({ chatId, messageId, before: safeBefore, after: safeAfter }).verbose('Fetching message context')
 
-    const messages = (await fetchMessageContextWithPhotos(chatId, messageId, safeBefore, safeAfter)).unwrap()
+    const messages = (await fetchMessageContextWithPhotos({ chatId, messageId, before: safeBefore, after: safeAfter })).unwrap()
 
-    emitter.emit('storage:messages:context', {
-      chatId,
-      messageId,
-      messages,
-    })
+    emitter.emit('storage:messages:context', { chatId, messageId, messages })
   })
 
   emitter.on('storage:record:messages', async ({ messages }) => {

--- a/packages/core/src/models/chat-message.ts
+++ b/packages/core/src/models/chat-message.ts
@@ -2,7 +2,7 @@
 
 import type { CorePagination } from '@tg-search/common'
 
-import type { CoreMessage, CoreMessageMediaPhoto, CoreMessageMediaSticker } from '../index'
+import type { CoreMessage, CoreMessageMediaPhoto, CoreMessageMediaSticker, StorageMessageContextParams } from '../index'
 import type { DBRetrievalMessages } from './utils/message'
 
 import { useLogger } from '@unbird/logg'
@@ -140,12 +140,7 @@ export async function fetchMessagesWithPhotos(chatId: string, pagination: CorePa
   }) satisfies CoreMessage))
 }
 
-export async function fetchMessageContextWithPhotos(
-  chatId: string,
-  messageId: string,
-  before: number,
-  after: number,
-) {
+export async function fetchMessageContextWithPhotos({ chatId, messageId, before, after }: Required<StorageMessageContextParams>) {
   const targetMessages = (await withDb(db => db
     .select()
     .from(chatMessagesTable)

--- a/packages/core/src/models/chat-message.ts
+++ b/packages/core/src/models/chat-message.ts
@@ -7,7 +7,7 @@ import type { DBRetrievalMessages } from './utils/message'
 
 import { useLogger } from '@unbird/logg'
 import { Ok } from '@unbird/result'
-import { desc, eq, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, lt, sql } from 'drizzle-orm'
 
 import { withDb } from '../db'
 import { chatMessagesTable } from '../schemas/chat_messages'
@@ -136,6 +136,72 @@ export async function fetchMessagesWithPhotos(chatId: string, pagination: CorePa
   return Ok(coreMessages.map((message, index) => ({
     ...message,
     media: (photosByMessage[dbMessagesResults[index].id] || [])
+      .map(convertDBPhotoToCoreMessageMedia),
+  }) satisfies CoreMessage))
+}
+
+export async function fetchMessageContextWithPhotos(
+  chatId: string,
+  messageId: string,
+  before: number,
+  after: number,
+) {
+  const targetMessages = (await withDb(db => db
+    .select()
+    .from(chatMessagesTable)
+    .where(and(
+      eq(chatMessagesTable.in_chat_id, chatId),
+      eq(chatMessagesTable.platform_message_id, messageId),
+    ))
+    .limit(1),
+  )).expect('Failed to locate target message')
+
+  if (targetMessages.length === 0)
+    return Ok<CoreMessage[]>([])
+
+  const targetMessage = targetMessages[0]
+
+  const previousMessages = (await withDb(db => db
+    .select()
+    .from(chatMessagesTable)
+    .where(and(
+      eq(chatMessagesTable.in_chat_id, chatId),
+      lt(chatMessagesTable.platform_timestamp, targetMessage.platform_timestamp),
+    ))
+    .orderBy(desc(chatMessagesTable.platform_timestamp))
+    .limit(before),
+  )).expect('Failed to fetch previous messages')
+
+  const nextMessages = (await withDb(db => db
+    .select()
+    .from(chatMessagesTable)
+    .where(and(
+      eq(chatMessagesTable.in_chat_id, chatId),
+      gt(chatMessagesTable.platform_timestamp, targetMessage.platform_timestamp),
+    ))
+    .orderBy(asc(chatMessagesTable.platform_timestamp))
+    .limit(after),
+  )).expect('Failed to fetch next messages')
+
+  const combinedDbMessages = [
+    ...previousMessages.reverse(),
+    targetMessage,
+    ...nextMessages,
+  ]
+
+  if (combinedDbMessages.length === 0)
+    return Ok<CoreMessage[]>([])
+
+  const messageIds = combinedDbMessages.map(msg => msg.id)
+  const photos = (await findPhotosByMessageIds(messageIds)).unwrap()
+  const photosByMessage = Object.groupBy(
+    photos.filter(photo => photo.message_id),
+    photo => photo.message_id!,
+  )
+
+  return Ok(combinedDbMessages.map(message => ({
+    ...convertToCoreMessageFromDB(message),
+    media: (photosByMessage[message.id] || [])
       .map(convertDBPhotoToCoreMessageMedia),
   }) satisfies CoreMessage))
 }

--- a/packages/core/src/services/storage.ts
+++ b/packages/core/src/services/storage.ts
@@ -25,6 +25,12 @@ export interface StorageEventToCore {
   'storage:record:dialogs': (data: { dialogs: CoreDialog[] }) => void
 
   'storage:search:messages': (data: CoreMessageSearchParams) => void
+  'storage:fetch:message-context': (data: {
+    chatId: string
+    messageId: string
+    before?: number
+    after?: number
+  }) => void
 }
 
 export interface StorageEventFromCore {
@@ -33,6 +39,7 @@ export interface StorageEventFromCore {
   'storage:dialogs': (data: { dialogs: CoreDialog[] }) => void
 
   'storage:search:messages:data': (data: { messages: CoreRetrievalMessages[] }) => void
+  'storage:messages:context': (data: { chatId: string, messageId: string, messages: CoreMessage[] }) => void
 }
 
 export type StorageEvent = StorageEventFromCore & StorageEventToCore

--- a/packages/core/src/services/storage.ts
+++ b/packages/core/src/services/storage.ts
@@ -17,6 +17,13 @@ export type CoreRetrievalMessages = CoreMessage & {
   combinedScore?: number
 }
 
+export interface StorageMessageContextParams {
+  chatId: string
+  messageId: string
+  before?: number
+  after?: number
+}
+
 export interface StorageEventToCore {
   'storage:fetch:messages': (data: { chatId: string, pagination: CorePagination }) => void
   'storage:record:messages': (data: { messages: CoreMessage[] }) => void
@@ -26,12 +33,7 @@ export interface StorageEventToCore {
 
   'storage:search:messages': (data: CoreMessageSearchParams) => void
 
-  'storage:fetch:message-context': (data: {
-    chatId: string
-    messageId: string
-    before?: number
-    after?: number
-  }) => void
+  'storage:fetch:message-context': (data: StorageMessageContextParams) => void
 }
 
 export interface StorageEventFromCore {
@@ -41,7 +43,7 @@ export interface StorageEventFromCore {
 
   'storage:search:messages:data': (data: { messages: CoreRetrievalMessages[] }) => void
 
-  'storage:messages:context': (data: { chatId: string, messageId: string, messages: CoreMessage[] }) => void
+  'storage:messages:context': (data: { messages: CoreMessage[] } & StorageMessageContextParams) => void
 }
 
 export type StorageEvent = StorageEventFromCore & StorageEventToCore

--- a/packages/core/src/services/storage.ts
+++ b/packages/core/src/services/storage.ts
@@ -25,6 +25,7 @@ export interface StorageEventToCore {
   'storage:record:dialogs': (data: { dialogs: CoreDialog[] }) => void
 
   'storage:search:messages': (data: CoreMessageSearchParams) => void
+
   'storage:fetch:message-context': (data: {
     chatId: string
     messageId: string
@@ -39,6 +40,7 @@ export interface StorageEventFromCore {
   'storage:dialogs': (data: { dialogs: CoreDialog[] }) => void
 
   'storage:search:messages:data': (data: { messages: CoreRetrievalMessages[] }) => void
+
   'storage:messages:context': (data: { chatId: string, messageId: string, messages: CoreMessage[] }) => void
 }
 

--- a/packages/stage-ui/src/components/VirtualMessageList.vue
+++ b/packages/stage-ui/src/components/VirtualMessageList.vue
@@ -88,6 +88,7 @@ const {
   // visibleRange is available but not currently used
   handleScroll,
   measureItem,
+  scrollToItem,
   scrollToBottom,
   getScrollOffset,
   restoreScrollPosition,
@@ -198,6 +199,14 @@ async function scrollToLatest() {
   isAtBottom.value = true
 }
 
+async function scrollToMessage(messageId: string | number) {
+  const targetIndex = virtualItems.value.findIndex(item => item.id === messageId)
+  if (targetIndex === -1)
+    return
+
+  await scrollToItem(targetIndex, 'center')
+}
+
 defineExpose({
   scrollToBottom: scrollToLatest,
   scrollToTop: () => {
@@ -207,6 +216,7 @@ defineExpose({
   },
   getScrollOffset,
   restoreScrollPosition,
+  scrollToMessage,
 })
 </script>
 

--- a/packages/stage-ui/src/components/messages/MessageList.vue
+++ b/packages/stage-ui/src/components/messages/MessageList.vue
@@ -4,6 +4,7 @@ import type { CoreMessage } from '@tg-search/core/types'
 import { useClipboard } from '@vueuse/core'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 
 import Avatar from '../ui/Avatar.vue'
 
@@ -12,6 +13,7 @@ const props = defineProps<{
   keyword: string
 }>()
 const { t } = useI18n()
+const router = useRouter()
 const hoveredMessage = ref<CoreMessage | null>(null)
 const { copy, copied } = useClipboard()
 
@@ -25,6 +27,16 @@ function highlightKeyword(text: string, keyword: string) {
 function copyMessageLink(message: CoreMessage) {
   copy(`https://t.me/c/${message.chatId}/${message.platformMessageId}`)
 }
+
+function navigateToMessage(message: CoreMessage) {
+  router.push({
+    path: `/chat/${message.chatId}`,
+    query: {
+      messageId: message.platformMessageId,
+      messageUuid: message.uuid,
+    },
+  })
+}
 </script>
 
 <template>
@@ -37,6 +49,7 @@ function copyMessageLink(message: CoreMessage) {
       @mouseenter="hoveredMessage = item"
       @mouseleave="hoveredMessage = null"
       @keydown.enter="copyMessageLink(item)"
+      @click="navigateToMessage(item)"
     >
       <Avatar
         :name="item.fromName"

--- a/packages/stage-ui/src/pages/chat/[id].vue
+++ b/packages/stage-ui/src/pages/chat/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CoreDialog } from '@tg-search/core/types'
+import type { CoreDialog, CoreMessage } from '@tg-search/core/types'
 
 import { useBridgeStore, useChatStore, useMessageStore, useSettingsStore } from '@tg-search/client'
 import { useWindowSize } from '@vueuse/core'
@@ -171,7 +171,7 @@ async function openMessageContext(messageId: string, messageUuid?: string) {
     await nextTick()
 
     const targetUuid = messageUuid
-      ?? messages.find(msg => msg.platformMessageId === messageId)?.uuid
+      ?? messages.find((msg: CoreMessage) => msg.platformMessageId === messageId)?.uuid
 
     if (targetUuid) {
       await nextTick()

--- a/packages/stage-ui/src/pages/chat/[id].vue
+++ b/packages/stage-ui/src/pages/chat/[id].vue
@@ -4,7 +4,7 @@ import type { CoreDialog } from '@tg-search/core/types'
 import { useBridgeStore, useChatStore, useMessageStore, useSettingsStore } from '@tg-search/client'
 import { useWindowSize } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
@@ -40,17 +40,32 @@ const searchDialogRef = ref<InstanceType<typeof SearchDialog> | null>(null)
 const isGlobalSearchOpen = ref(false)
 
 const messageInput = ref('')
+const isContextMode = ref(false)
+const isContextLoading = ref(false)
+
+const targetMessageParams = computed(() => ({
+  messageId: route.query.messageId as string | undefined,
+  messageUuid: route.query.messageUuid as string | undefined,
+}))
 
 // Initial load when component mounts
 onMounted(async () => {
-  // Only load if there are no messages yet
-  if (sortedMessageIds.value.length === 0) {
+  const initialMessageId = targetMessageParams.value.messageId
+
+  if (typeof initialMessageId === 'string' && initialMessageId.length > 0) {
+    await openMessageContext(initialMessageId, targetMessageParams.value.messageUuid)
+  }
+
+  // Only load if there are no messages yet and we are not in context mode
+  if (!isContextMode.value && sortedMessageIds.value.length === 0) {
     await loadOlderMessages()
   }
 })
 
 // Load older messages when scrolling to top
 async function loadOlderMessages() {
+  if (isContextMode.value)
+    return
   if (isLoadingOlder.value || isLoadingMessages.value)
     return
 
@@ -70,6 +85,8 @@ async function loadOlderMessages() {
 
 // Load newer messages when scrolling to bottom
 async function loadNewerMessages() {
+  if (isContextMode.value)
+    return
   if (isLoadingNewer.value || isLoadingMessages.value)
     return
 
@@ -124,6 +141,65 @@ function sendMessage() {
 
   toast.success(t('chat.messageSent'))
 }
+
+function resetPagination() {
+  messageOffset.value = 0
+}
+
+async function openMessageContext(messageId: string, messageUuid?: string) {
+  if (!messageId || isContextLoading.value)
+    return
+
+  isContextLoading.value = true
+  isContextMode.value = true
+  resetPagination()
+
+  try {
+    const messages = await messageStore.loadMessageContext(id.toString(), messageId, {
+      before: 40,
+      after: 40,
+      limit: messageLimit.value,
+    })
+
+    if (messages.length === 0) {
+      isContextMode.value = false
+      toast.warning(t('search.noRelatedMessages'))
+      await loadOlderMessages()
+      return
+    }
+
+    await nextTick()
+
+    const targetUuid = messageUuid
+      ?? messages.find(msg => msg.platformMessageId === messageId)?.uuid
+
+    if (targetUuid) {
+      await nextTick()
+      virtualListRef.value?.scrollToMessage(targetUuid)
+    }
+  }
+  finally {
+    isContextLoading.value = false
+  }
+}
+
+watch(
+  () => [targetMessageParams.value.messageId, targetMessageParams.value.messageUuid],
+  async ([newMessageId, newMessageUuid], [oldMessageId]) => {
+    if (newMessageId === oldMessageId)
+      return
+
+    if (typeof newMessageId === 'string' && newMessageId.length > 0) {
+      await openMessageContext(newMessageId, typeof newMessageUuid === 'string' ? newMessageUuid : undefined)
+    }
+    else if (oldMessageId) {
+      isContextMode.value = false
+      resetPagination()
+      messageStore.replaceMessages([], { chatId: id.toString(), limit: messageLimit.value })
+      await loadOlderMessages()
+    }
+  },
+)
 </script>
 
 <template>
@@ -182,6 +258,7 @@ function sendMessage() {
         :messages="sortedMessageArray"
         :on-scroll-to-top="loadOlderMessages"
         :on-scroll-to-bottom="loadNewerMessages"
+        :auto-scroll-to-bottom="!isContextMode"
         @scroll="handleVirtualListScroll"
       />
     </div>


### PR DESCRIPTION
close #211 

## Summary
- allow clicking a search result to route directly to the related chat message
- load a focused message context in the chat view via a new storage event and scroll helper
- extend the message store, virtual list, and core storage service to support contextual fetches

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d284a2455c832e80f603fb3c8dffdb