### PR TITLE
refactor: parse env to flags

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -18,7 +18,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install
-      - run: pnpm run typecheck
+      - run: pnpm prune && pnpm dedupe
       - run: pnpm run lint:fix
 
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,6 @@
 - Build packages: `pnpm run packages:build`
 - Tests: `pnpm test` (Vitest)
 - Lint: `pnpm lint` | fix: `pnpm lint:fix`
-- DB (Drizzle): `pnpm run db:migrate` | `pnpm run db:push`
 
 ## Coding Style & Naming Conventions
 - Language: TypeScript, strict mode enabled. Vue 3 for UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,6 @@ Telegram Search is a powerful Telegram chat history search tool with vector sear
 - `pnpm run typecheck` - Run TypeScript type checking across all packages
 
 ### Database Operations
-- `pnpm run db:migrate` - Run database migrations
-- `pnpm run db:push` - Push schema changes to database
 - `pnpm run db:generate` - Generate Drizzle migration files
 - `pnpm run db:kit` - Run database utility scripts
 
@@ -62,8 +60,7 @@ Frontend (Vue) ↔ WebSocket ↔ Server ↔ Core Context ↔ Telegram API
 
 1. Copy configuration: `cp config/config.example.yaml config/config.yaml`
 2. Start database: `docker compose up -d pgvector`
-3. Run migrations: `pnpm run db:migrate`
-4. Start development servers:
+3. Start development servers:
    - Backend: `pnpm run server:dev`
    - Frontend: `pnpm run web:dev`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,7 @@ cp config/config.example.yaml config/config.yaml
 docker compose up -d pgvector
 ```
 
-5. Sync database schema:
-
-```bash
-pnpm run db:migrate
-```
-
-6. Start services:
+5. Start services:
 
 ```bash
 # Start backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# ---------------------------------
+# --------- Builder Stage ---------
+# ---------------------------------
 FROM node:alpine3.21 AS builder
 
 # Install pnpm and basic tools
@@ -10,15 +13,18 @@ COPY . .
 # Install dependencies
 RUN CI=true pnpm install --frozen-lockfile --ignore-scripts
 
+# Build packages first (required by web build)
+RUN pnpm run packages:build
+
 # Build web client
-ENTRYPOINT ["/bin/sh", "-c", "pnpm run web:build"]
+RUN pnpm run web:build
 
 # ---------------------------------
 # --------- Runtime Stage ---------
 # ---------------------------------
 FROM alpine:latest
 
-RUN apk add --no-cache nodejs pnpm
+RUN apk add --no-cache nodejs pnpm curl
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,11 @@ WORKDIR /app
 
 COPY --from=builder /app /app
 
-ENV DATABASE_URL="postgresql://postgres:123456@pgvector:5432/postgres"
-ENV TELEGRAM_API_ID=""
-ENV TELEGRAM_API_HASH=""
-ENV EMBEDDING_API_KEY=""
-ENV EMBEDDING_BASE_URL=""
+ENV DATABASE_TYPE="pglite"
+ENV DATABASE_URL=""
+ENV TELEGRAM_API_ID="611335"
+ENV TELEGRAM_API_HASH="d524b414d21f4d37f08684c1df41ac9c"
+ENV EMBEDDING_API_KEY="sk-proj-1234567890"
+ENV EMBEDDING_BASE_URL="https://api.openai.com/v1"
 
-ENTRYPOINT ["/bin/sh", "-c", "pnpm run db:migrate && exec pnpm run start"]
+ENTRYPOINT ["/bin/sh", "-c", "exec pnpm run start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 
 COPY --from=builder /app /app
 
-ENV DATABASE_URL=""
+ENV DATABASE_URL="postgresql://postgres:123456@pgvector:5432/postgres"
 ENV TELEGRAM_API_ID=""
 ENV TELEGRAM_API_HASH=""
 ENV EMBEDDING_API_KEY=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,10 @@ WORKDIR /app
 
 COPY --from=builder /app /app
 
-ENTRYPOINT ["/bin/sh", "-c", "pnpm run db:migrate && DATABASE_URL=postgresql://postgres:123456@pgvector:5432/postgres pnpm run start"]
+ENV DATABASE_URL=""
+ENV TELEGRAM_API_ID=""
+ENV TELEGRAM_API_HASH=""
+ENV EMBEDDING_API_KEY=""
+ENV EMBEDDING_BASE_URL=""
+
+ENTRYPOINT ["/bin/sh", "-c", "pnpm run db:migrate && exec pnpm run start"]

--- a/README.md
+++ b/README.md
@@ -135,13 +135,7 @@ cp config/config.example.yaml config/config.yaml
 docker compose up -d pgvector
 ```
 
-5. Sync database schema:
-
-```bash
-pnpm run db:migrate
-```
-
-6. Start services:
+5. Start services:
 
 ```bash
 # Start backend

--- a/README.md
+++ b/README.md
@@ -42,27 +42,36 @@ Set the following environment variables before starting the containerized servic
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `TELEGRAM_API_ID` | ✅ | Telegram app ID from [my.telegram.org](https://my.telegram.org/apps). |
-| `TELEGRAM_API_HASH` | ✅ | Telegram app hash from the same page. |
-| `DATABASE_URL` | ✅ | PostgreSQL connection string used by the server and migrations. |
-| `EMBEDDING_API_KEY` | ✅ | API key for the embedding provider (OpenAI key, Ollama token, etc.). |
+| `TELEGRAM_API_ID` | optional | Telegram app ID from [my.telegram.org](https://my.telegram.org/apps). |
+| `TELEGRAM_API_HASH` | optional | Telegram app hash from the same page. |
+| `DATABASE_TYPE` | optional | Database type (`postgres` or `pglite`). |
+| `DATABASE_URL` | optional | Database connection string used by the server and migrations (Only support when `DATABASE_TYPE` is `postgres`). |
+| `EMBEDDING_API_KEY` | optional | API key for the embedding provider (OpenAI key, Ollama token, etc.). |
 | `EMBEDDING_BASE_URL` | optional | Custom base URL for self-hosted or compatible embedding providers. |
 | `EMBEDDING_PROVIDER` | optional | Override embedding provider (`openai` or `ollama`). |
 | `EMBEDDING_MODEL` | optional | Override embedding model name. |
 | `EMBEDDING_DIMENSION` | optional | Override embedding dimension (e.g. `1536`, `1024`, `768`). |
-| `PGVECTOR_HOST_PORT` | optional | Publish pgvector on a host port when set (e.g. `15432`). |
-| `PGVECTOR_HOST_IP` | optional | Bind pgvector to a specific host interface when exposing the port. |
 
 ### Start with Docker Image
 
-1. Run docker image with the required environment variables:
+1. Run docker image default without any environment variables:
+
+```bash
+docker run -d --name telegram-search \
+  -p 3333:3333 \
+  ghcr.io/groupultra/telegram-search:latest
+```
+
+<details>
+<summary>Example with environment variables</summary>
 
 ```bash
 docker run -d --name telegram-search \
   -p 3333:3333 \
   -e TELEGRAM_API_ID=611335 \
   -e TELEGRAM_API_HASH=d524b414d21f4d37f08684c1df41ac9c \
-  -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
+  -e DATABASE_TYPE=postgres \
+  -e DATABASE_URL=postgresql://<postgres-host>:5432/postgres \
   -e EMBEDDING_API_KEY=sk-xxxx \
   -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \
   ghcr.io/groupultra/telegram-search:latest
@@ -70,29 +79,21 @@ docker run -d --name telegram-search \
 
 Replace `<postgres-host>` with the hostname or IP address of the PostgreSQL instance you want to use.
 
+</details>
+
 2. Access `http://localhost:3333` to open the search interface.
 
 ### Start with Docker Compose
 
 1. Clone repository.
 
-2. Create a `.env` file at the repository root with the environment variables listed above (only include the ones you use).
-
-3. Run docker compose to start all services including the database:
+2. Run docker compose to start all services including the database:
 
 ```bash
 docker compose up -d
 ```
 
-4. Access `http://localhost:3333` to open the search interface.
-
-5. To expose the pgvector database port outside Docker set `PGVECTOR_HOST_PORT` when starting:
-
-```bash
-PGVECTOR_HOST_PORT=15432 docker compose up -d
-```
-
-   Optionally set `PGVECTOR_HOST_IP=127.0.0.1` to bind on a specific interface.
+3. Access `http://localhost:3333` to open the search interface.
 
 ## 💻 Development Guide
 

--- a/README.md
+++ b/README.md
@@ -36,28 +36,63 @@ Visit: https://search.lingogram.app
 
 ## 🚀 Quick Start
 
+### Runtime environment variables
+
+Set the following environment variables before starting the containerized services:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `TELEGRAM_API_ID` | ✅ | Telegram app ID from [my.telegram.org](https://my.telegram.org/apps). |
+| `TELEGRAM_API_HASH` | ✅ | Telegram app hash from the same page. |
+| `DATABASE_URL` | ✅ | PostgreSQL connection string used by the server and migrations. |
+| `EMBEDDING_API_KEY` | ✅ | API key for the embedding provider (OpenAI key, Ollama token, etc.). |
+| `EMBEDDING_BASE_URL` | optional | Custom base URL for self-hosted or compatible embedding providers. |
+| `EMBEDDING_PROVIDER` | optional | Override embedding provider (`openai` or `ollama`). |
+| `EMBEDDING_MODEL` | optional | Override embedding model name. |
+| `EMBEDDING_DIMENSION` | optional | Override embedding dimension (e.g. `1536`, `1024`, `768`). |
+| `PGVECTOR_HOST_PORT` | optional | Publish pgvector on a host port when set (e.g. `15432`). |
+| `PGVECTOR_HOST_IP` | optional | Bind pgvector to a specific host interface when exposing the port. |
+
 ### Start with Docker Image
 
-1. Run docker image
+1. Run docker image with the required environment variables:
 
 ```bash
-docker run ghcr.io/groupultra/telegram-search:latest -d
+docker run -d --name telegram-search \
+  -p 3333:3333 \
+  -e TELEGRAM_API_ID=123456 \
+  -e TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef \
+  -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
+  -e EMBEDDING_API_KEY=sk-xxxx \
+  -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \
+  ghcr.io/groupultra/telegram-search:latest
 ```
+
+Replace `<postgres-host>` with the hostname or IP address of the PostgreSQL instance you want to use.
 
 2. Access `http://localhost:3333` to open the search interface.
 
-
 ### Start with Docker Compose
 
-1. Clone repository
+1. Clone repository.
 
-2. Run docker compose to start all services including database
+2. Create a `.env` file at the repository root with the environment variables listed above (only include the ones you use).
+
+3. Run docker compose to start all services including the database:
 
 ```bash
 docker compose up -d
 ```
 
-3. Access `http://localhost:3333` to open the search interface.
+4. Access `http://localhost:3333` to open the search interface.
+
+5. To expose the pgvector database port outside Docker set `PGVECTOR_HOST_PORT` when starting:
+
+```bash
+PGVECTOR_HOST_PORT=15432 docker compose up -d
+```
+
+   Optionally set `PGVECTOR_HOST_IP=127.0.0.1` to bind on a specific interface.
 
 ## 💻 Development Guide
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Set the following environment variables before starting the containerized servic
 ```bash
 docker run -d --name telegram-search \
   -p 3333:3333 \
-  -e TELEGRAM_API_ID=123456 \
-  -e TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef \
+  -e TELEGRAM_API_ID=611335 \
+  -e TELEGRAM_API_HASH=d524b414d21f4d37f08684c1df41ac9c \
   -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
   -e EMBEDDING_API_KEY=sk-xxxx \
   -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,32 +1,15 @@
+import type { RuntimeFlags } from '@tg-search/common'
 import type { CrossWSOptions } from 'listhen'
 
 import process from 'node:process'
 
-import { flags, initConfig, parseEnvFlags } from '@tg-search/common'
+import { initConfig, parseEnvFlags } from '@tg-search/common'
 import { initDrizzle } from '@tg-search/core'
 import { initLogger, useLogger } from '@unbird/logg'
 import { createApp, toNodeListener } from 'h3'
 import { listen } from 'listhen'
 
 import { setupWsRoutes } from './ws/routes'
-
-async function initCore(): Promise<ReturnType<typeof useLogger>> {
-  parseEnvFlags(process.env as Record<string, string>)
-  initLogger()
-  const logger = useLogger()
-  const config = await initConfig()
-
-  try {
-    await initDrizzle(logger, config)
-    logger.log('Database initialized successfully')
-  }
-  catch (error) {
-    logger.withError(error).error('Failed to initialize services')
-    process.exit(1)
-  }
-
-  return logger
-}
 
 function setupErrorHandlers(logger: ReturnType<typeof useLogger>): void {
   // TODO: fix type
@@ -38,7 +21,7 @@ function setupErrorHandlers(logger: ReturnType<typeof useLogger>): void {
   process.on('unhandledRejection', error => handleError(error, 'Unhandled rejection'))
 }
 
-function configureServer(logger: ReturnType<typeof useLogger>) {
+function configureServer(logger: ReturnType<typeof useLogger>, flags: RuntimeFlags) {
   const app = createApp({
     debug: flags.isDebugMode,
     onRequest(event) {
@@ -94,10 +77,23 @@ function configureServer(logger: ReturnType<typeof useLogger>) {
 }
 
 async function bootstrap() {
-  const logger = await initCore()
+  const flags = parseEnvFlags(process.env as Record<string, string>)
+  initLogger()
+  const logger = useLogger()
+  const config = await initConfig(flags)
+
+  try {
+    await initDrizzle(logger, config, { isDatabaseDebugMode: flags.isDatabaseDebugMode })
+    logger.log('Database initialized successfully')
+  }
+  catch (error) {
+    logger.withError(error).error('Failed to initialize services')
+    process.exit(1)
+  }
+
   setupErrorHandlers(logger)
 
-  const app = configureServer(logger)
+  const app = configureServer(logger, flags)
   const listener = toNodeListener(app)
 
   const port = process.env.PORT ? Number(process.env.PORT) : 3000

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -6,7 +6,7 @@ import process from 'node:process'
 import { initConfig, parseEnvFlags } from '@tg-search/common'
 import { initDrizzle } from '@tg-search/core'
 import { initLogger, useLogger } from '@unbird/logg'
-import { createApp, toNodeListener } from 'h3'
+import { createApp, createRouter, defineEventHandler, toNodeListener } from 'h3'
 import { listen } from 'listhen'
 
 import { setupWsRoutes } from './ws/routes'
@@ -71,6 +71,12 @@ function configureServer(logger: ReturnType<typeof useLogger>, flags: RuntimeFla
   //   }
   // }))
 
+  const router = createRouter()
+  router.get('/health', defineEventHandler(() => {
+    return Response.json({ success: true })
+  }))
+
+  app.use(router)
   setupWsRoutes(app)
 
   return app

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -5,7 +5,7 @@ database:
 
   # PostgreSQL configuration (used when type: postgres)
   host: localhost
-  port: 5433 # 5433 for local, 5432 for docker
+  port: 5433
   user: postgres
   password: '123456'
   database: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,14 @@ services:
       - ./config/:/app/config/
       - app_data:/root/.telegram-search
     restart: none
+    healthcheck:
+      test: |
+        curl -f http://localhost:3333 || exit 1;
+        curl -f http://localhost:3333/api/health || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 volumes:
   pgvector_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,6 @@ services:
     volumes:
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - pgvector_data:/var/lib/postgresql/data
-    expose:
-      - 5432
-    ports:
-      - target: 5432
-        published: ${PGVECTOR_HOST_PORT:-null}
-        protocol: tcp
-        host_ip: ${PGVECTOR_HOST_IP:-null}
     healthcheck:
       test: [CMD-SHELL, pg_isready -d postgres -U postgres]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,13 @@ services:
     volumes:
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - pgvector_data:/var/lib/postgresql/data
+    expose:
+      - 5432
+    ports:
+      - target: 5432
+        published: ${PGVECTOR_HOST_PORT:-null}
+        protocol: tcp
+        host_ip: ${PGVECTOR_HOST_IP:-null}
     healthcheck:
       test: [CMD-SHELL, pg_isready -d postgres -U postgres]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - ./config/:/app/config/
       - app_data:/root/.telegram-search
     restart: none
+    environment:
+      DATABASE_TYPE: postgres
+      DATABASE_URL: "postgresql://postgres:123456@pgvector:5432/postgres"
     healthcheck:
       test: |
         curl -f http://localhost:3333 || exit 1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     restart: none
     environment:
       DATABASE_TYPE: postgres
-      DATABASE_URL: "postgresql://postgres:123456@pgvector:5432/postgres"
+      DATABASE_URL: 'postgresql://postgres:123456@pgvector:5432/postgres'
     healthcheck:
       test: |
         curl -f http://localhost:3333 || exit 1;

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -44,27 +44,36 @@
 
 | 变量 | 是否必填 | 说明 |
 | --- | --- | --- |
-| `TELEGRAM_API_ID` | ✅ | 来自 [my.telegram.org](https://my.telegram.org/apps) 的 Telegram 应用 ID。 |
-| `TELEGRAM_API_HASH` | ✅ | 来自同一页面的 Telegram 应用 Hash。 |
-| `DATABASE_URL` | ✅ | 后端及迁移脚本使用的 PostgreSQL 连接串。 |
-| `EMBEDDING_API_KEY` | ✅ | 向量嵌入提供商的 API Key（OpenAI、Ollama 等）。 |
+| `TELEGRAM_API_ID` | 选填 | 来自 [my.telegram.org](https://my.telegram.org/apps) 的 Telegram 应用 ID。 |
+| `TELEGRAM_API_HASH` | 选填 | 来自同一页面的 Telegram 应用 Hash。 |
+| `DATABASE_TYPE` | 选填 | 数据库类型（`postgres` 或 `pglite`）。 |
+| `DATABASE_URL` | 选填 | 后端及迁移脚本使用的数据库连接串（仅当 `DATABASE_TYPE` 为 `postgres` 时支持）。 |
+| `EMBEDDING_API_KEY` | 选填 | 向量嵌入提供商的 API Key（OpenAI、Ollama 等）。 |
 | `EMBEDDING_BASE_URL` | 选填 | 自建或兼容服务的 API Base URL。 |
 | `EMBEDDING_PROVIDER` | 选填 | 指定嵌入服务提供商（`openai` 或 `ollama`）。 |
 | `EMBEDDING_MODEL` | 选填 | 覆盖默认的嵌入模型名称。 |
 | `EMBEDDING_DIMENSION` | 选填 | 覆盖嵌入向量维度（如 `1536`、`1024`、`768`）。 |
-| `PGVECTOR_HOST_PORT` | 选填 | 需要向外暴露数据库时使用的宿主机端口（例如 `15432`）。 |
-| `PGVECTOR_HOST_IP` | 选填 | 暴露端口时绑定的宿主机 IP（例如仅监听本地的 `127.0.0.1`）。 |
 
 ### 使用 Docker 镜像
 
-1. 携带必要环境变量运行镜像：
+1. 不带任何环境变量运行默认镜像：
 
 ```bash
 docker run -d --name telegram-search \
   -p 3333:3333 \
-  -e TELEGRAM_API_ID=123456 \
-  -e TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef \
-  -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
+  ghcr.io/groupultra/telegram-search:latest
+```
+
+<details>
+<summary>带环境变量的示例</summary>
+
+```bash
+docker run -d --name telegram-search \
+  -p 3333:3333 \
+  -e TELEGRAM_API_ID=611335 \
+  -e TELEGRAM_API_HASH=d524b414d21f4d37f08684c1df41ac9c \
+  -e DATABASE_TYPE=postgres \
+  -e DATABASE_URL=postgresql://<postgres-host>:5432/postgres \
   -e EMBEDDING_API_KEY=sk-xxxx \
   -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \
   ghcr.io/groupultra/telegram-search:latest
@@ -72,29 +81,21 @@ docker run -d --name telegram-search \
 
 请将 `<postgres-host>` 替换为实际的 PostgreSQL 主机名或 IP 地址。
 
+</details>
+
 2. 浏览器访问 `http://localhost:3333` 打开搜索界面。
 
 ### 使用 Docker Compose
 
 1. 克隆仓库。
 
-2. 在仓库根目录创建 `.env` 文件，写入上表中的环境变量（仅保留实际需要的条目）。
-
-3. 运行 docker compose 启动包括数据库在内的全部服务：
+2. 运行 docker compose 启动包括数据库在内的全部服务：
 
 ```bash
 docker compose up -d
 ```
 
-4. 浏览器访问 `http://localhost:3333` 打开搜索界面。
-
-5. 如需向外暴露 pgvector 端口，可在启动时设置 `PGVECTOR_HOST_PORT`：
-
-```bash
-PGVECTOR_HOST_PORT=15432 docker compose up -d
-```
-
-   如果只想监听本机，可额外设置 `PGVECTOR_HOST_IP=127.0.0.1`。
+3. 浏览器访问 `http://localhost:3333` 打开搜索界面。
 
 ## 💻 开发教程
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -137,13 +137,7 @@ cp config/config.example.yaml config/config.yaml
 docker compose up -d pgvector
 ```
 
-5. 同步数据库表结构：
-
-```bash
-pnpm run db:migrate
-```
-
-6. 启动服务：
+5. 启动服务：
 
 ```bash
 # 启动后端服务

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -38,27 +38,63 @@
 
 ## 🚀 快速开始
 
+### 运行时环境变量
+
+启动容器前请准备以下环境变量：
+
+| 变量 | 是否必填 | 说明 |
+| --- | --- | --- |
+| `TELEGRAM_API_ID` | ✅ | 来自 [my.telegram.org](https://my.telegram.org/apps) 的 Telegram 应用 ID。 |
+| `TELEGRAM_API_HASH` | ✅ | 来自同一页面的 Telegram 应用 Hash。 |
+| `DATABASE_URL` | ✅ | 后端及迁移脚本使用的 PostgreSQL 连接串。 |
+| `EMBEDDING_API_KEY` | ✅ | 向量嵌入提供商的 API Key（OpenAI、Ollama 等）。 |
+| `EMBEDDING_BASE_URL` | 选填 | 自建或兼容服务的 API Base URL。 |
+| `EMBEDDING_PROVIDER` | 选填 | 指定嵌入服务提供商（`openai` 或 `ollama`）。 |
+| `EMBEDDING_MODEL` | 选填 | 覆盖默认的嵌入模型名称。 |
+| `EMBEDDING_DIMENSION` | 选填 | 覆盖嵌入向量维度（如 `1536`、`1024`、`768`）。 |
+| `PGVECTOR_HOST_PORT` | 选填 | 需要向外暴露数据库时使用的宿主机端口（例如 `15432`）。 |
+| `PGVECTOR_HOST_IP` | 选填 | 暴露端口时绑定的宿主机 IP（例如仅监听本地的 `127.0.0.1`）。 |
+
 ### 使用 Docker 镜像
 
-1. 运行 Docker 镜像
+1. 携带必要环境变量运行镜像：
 
 ```bash
-docker run ghcr.io/groupultra/telegram-search:latest -d
+docker run -d --name telegram-search \
+  -p 3333:3333 \
+  -e TELEGRAM_API_ID=123456 \
+  -e TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef \
+  -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
+  -e EMBEDDING_API_KEY=sk-xxxx \
+  -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \
+  ghcr.io/groupultra/telegram-search:latest
 ```
 
-2. 访问 `http://localhost:3333` 即可打开搜索界面。
+请将 `<postgres-host>` 替换为实际的 PostgreSQL 主机名或 IP 地址。
+
+2. 浏览器访问 `http://localhost:3333` 打开搜索界面。
 
 ### 使用 Docker Compose
 
-1. 克隆仓库
+1. 克隆仓库。
 
-2. 运行 docker compose 启动所有服务包括数据库
+2. 在仓库根目录创建 `.env` 文件，写入上表中的环境变量（仅保留实际需要的条目）。
+
+3. 运行 docker compose 启动包括数据库在内的全部服务：
 
 ```bash
 docker compose up -d
 ```
 
-3. 访问 `http://localhost:3333` 即可打开搜索界面。
+4. 浏览器访问 `http://localhost:3333` 打开搜索界面。
+
+5. 如需向外暴露 pgvector 端口，可在启动时设置 `PGVECTOR_HOST_PORT`：
+
+```bash
+PGVECTOR_HOST_PORT=15432 docker compose up -d
+```
+
+   如果只想监听本机，可额外设置 `PGVECTOR_HOST_IP=127.0.0.1`。
 
 ## 💻 开发教程
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -136,13 +136,7 @@ cp config/config.example.yaml config/config.yaml
 docker compose up -d pgvector
 ```
 
-5. データベーススキーマを同期:
-
-```bash
-pnpm run db:migrate
-```
-
-6. サービスを起動:
+5. サービスを起動:
 
 ```bash
 # バックエンドを起動

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  [<a href="https://search.lingogram.app">すぐに使用</a>] [<a href="https://discord.gg/NzYsmJSgCT">Discordサーバーに参加</a>] [<a href="../README.md">English</a>] [<a href="./README_CN.md">简体中文</a>]
+  [<a href="https://search.lingogram.app">すぐに使用</a>] [<a href="https://discord.gg/NzYsmJSgCT">Discord サーバーに参加</a>] [<a href="../README.md">English</a>] [<a href="./README_CN.md">简体中文</a>]
 </p>
 
 <p align="center">
@@ -22,7 +22,7 @@
 >
 > このソフトウェアは自分のチャット履歴をエクスポートして検索するためのものです。違法な目的で使用しないでください。
 
-ベクトル検索とセマンティックマッチングをサポートする強力なTelegramチャット履歴検索ツール。OpenAIのセマンティックベクトル技術に基づいて、Telegramメッセージの検索をよりスマートで正確にします。
+ベクトル検索とセマンティックマッチングをサポートする強力な Telegram チャット履歴検索ツール。OpenAI のセマンティックベクトル技術に基づいて、Telegram メッセージの検索をよりスマートで正確にします。
 
 ## 💖 スポンサー
 
@@ -30,10 +30,10 @@
 
 ## 🌐 すぐに使用
 
-我々はオンラインバージョンを提供しており、Telegram Searchのすべての機能を体験できます。
+我々はオンラインバージョンを提供しており、Telegram Search のすべての機能を体験できます。
 > 我々はあなたのプライバシーを尊重します。
 
-以下のURLから開始してください: https://search.lingogram.app
+以下の URL から開始してください：https://search.lingogram.app
 
 ## 🚀 クイックスタート
 
@@ -43,27 +43,36 @@
 
 | 変数 | 必須 | 説明 |
 | --- | --- | --- |
-| `TELEGRAM_API_ID` | ✅ | [my.telegram.org](https://my.telegram.org/apps) で取得した Telegram アプリ ID。 |
-| `TELEGRAM_API_HASH` | ✅ | 同じページで取得できる Telegram アプリ Hash。 |
-| `DATABASE_URL` | ✅ | サーバーとマイグレーションが利用する PostgreSQL 接続文字列。 |
-| `EMBEDDING_API_KEY` | ✅ | 埋め込みプロバイダーの API キー（OpenAI、Ollama など）。 |
+| `TELEGRAM_API_ID` | 任意 | [my.telegram.org](https://my.telegram.org/apps) で取得した Telegram アプリ ID。 |
+| `TELEGRAM_API_HASH` | 任意 | 同じページで取得できる Telegram アプリ Hash。 |
+| `DATABASE_TYPE` | 任意 | データベースタイプ（`postgres` または `pglite`）。 |
+| `DATABASE_URL` | 任意 | サーバーとマイグレーションが利用するデータベース接続文字列（`DATABASE_TYPE` が `postgres` の場合のみサポート）。 |
+| `EMBEDDING_API_KEY` | 任意 | 埋め込みプロバイダーの API キー（OpenAI、Ollama など）。 |
 | `EMBEDDING_BASE_URL` | 任意 | 自前ホストや互換プロバイダー向けの API ベース URL。 |
 | `EMBEDDING_PROVIDER` | 任意 | 埋め込みプロバイダーを上書き（`openai` または `ollama`）。 |
 | `EMBEDDING_MODEL` | 任意 | 使用する埋め込みモデル名を上書き。 |
 | `EMBEDDING_DIMENSION` | 任意 | 埋め込みベクトルの次元数を上書き（`1536`、`1024`、`768` など）。 |
-| `PGVECTOR_HOST_PORT` | 任意 | pgvector を外部公開するときのホスト側ポート（例: `15432`）。 |
-| `PGVECTOR_HOST_IP` | 任意 | ポート公開時にバインドするホスト IP（例: `127.0.0.1` のみで待ち受け）。 |
 
 ### Docker イメージから起動
 
-1. 必要な環境変数を指定してイメージを実行します。
+1. 環境変数なしでデフォルトイメージを実行します。
 
 ```bash
 docker run -d --name telegram-search \
   -p 3333:3333 \
-  -e TELEGRAM_API_ID=123456 \
-  -e TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef \
-  -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
+  ghcr.io/groupultra/telegram-search:latest
+```
+
+<details>
+<summary>環境変数ありの例</summary>
+
+```bash
+docker run -d --name telegram-search \
+  -p 3333:3333 \
+  -e TELEGRAM_API_ID=611335 \
+  -e TELEGRAM_API_HASH=d524b414d21f4d37f08684c1df41ac9c \
+  -e DATABASE_TYPE=postgres \
+  -e DATABASE_URL=postgresql://<postgres-host>:5432/postgres \
   -e EMBEDDING_API_KEY=sk-xxxx \
   -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \
   ghcr.io/groupultra/telegram-search:latest
@@ -71,29 +80,21 @@ docker run -d --name telegram-search \
 
 `<postgres-host>` には利用したい PostgreSQL のホスト名または IP アドレスを指定してください。
 
+</details>
+
 2. http://localhost:3333 にアクセスして検索インターフェースを開きます。
 
 ### Docker Compose で起動
 
 1. リポジトリをクローンします。
 
-2. ルートディレクトリに `.env` ファイルを作成し、上記の環境変数（必要なものだけ）を記載します。
-
-3. docker compose を実行してすべてのサービスを起動します。
+2. docker compose を実行してすべてのサービスを起動します。
 
 ```bash
 docker compose up -d
 ```
 
-4. http://localhost:3333 にアクセスして検索インターフェースを開きます。
-
-5. pgvector のポートを外部公開したい場合は、起動時に `PGVECTOR_HOST_PORT` を指定してください。
-
-```bash
-PGVECTOR_HOST_PORT=15432 docker compose up -d
-```
-
-   特定のインターフェースだけで待ち受けたい場合は `PGVECTOR_HOST_IP=127.0.0.1` も併せて指定します。
+3. http://localhost:3333 にアクセスして検索インターフェースを開きます。
 
 ## 💻 開発ガイド
 
@@ -107,7 +108,7 @@ PGVECTOR_HOST_PORT=15432 docker compose up -d
 pnpm install
 ```
 
-3. 開発サーバーを起動:
+3. 開発サーバーを起動：
 
 ```bash
 pnpm run dev
@@ -129,14 +130,14 @@ pnpm install
 cp config/config.example.yaml config/config.yaml
 ```
 
-4. データベースコンテナを起動:
+4. データベースコンテナを起動：
 
 ```bash
-# ローカル開発では、Dockerはデータベースコンテナのみに使用されます。
+# ローカル開発では、Docker はデータベースコンテナのみに使用されます。
 docker compose up -d pgvector
 ```
 
-5. サービスを起動:
+5. サービスを起動：
 
 ```bash
 # バックエンドを起動
@@ -151,8 +152,8 @@ pnpm run web:dev
 ```mermaid
 graph TB
     subgraph "🖥️ フロントエンドレイヤー"
-        Frontend["Webフロントエンド<br/>(Vue 3 + Pinia)"]
-        Electron["Electronデスクトップ"]
+        Frontend["Web フロントエンド<br/>(Vue 3 + Pinia)"]
+        Electron["Electron デスクトップ"]
         
         subgraph "クライアントイベントハンドラー"
             ClientAuth["認証ハンドラー"]
@@ -164,14 +165,14 @@ graph TB
     end
 
     subgraph "🌐 通信レイヤー"
-        WS["WebSocketイベントブリッジ<br/>リアルタイム双方向通信<br/>• イベント登録<br/>• イベント転送<br/>• セッション管理"]
+        WS["WebSocket イベントブリッジ<br/>リアルタイム双方向通信<br/>• イベント登録<br/>• イベント転送<br/>• セッション管理"]
     end
 
     subgraph "🚀 バックエンドサービスレイヤー"
         Server["バックエンドサーバー<br/>(REST API)"]
         
         subgraph "セッション管理"
-            SessionMgr["セッションマネージャー<br/>• クライアント状態<br/>• CoreContextインスタンス<br/>• イベントリスナー"]
+            SessionMgr["セッションマネージャー<br/>• クライアント状態<br/>• CoreContext インスタンス<br/>• イベントリスナー"]
         end
     end
 
@@ -185,7 +186,7 @@ graph TB
             StorageHandler["📦 ストレージハンドラー"]
             ConfigHandler["⚙️ 設定ハンドラー"]
             EntityHandler["👤 エンティティハンドラー"]
-            GramEventsHandler["📡 Gramイベントハンドラー"]
+            GramEventsHandler["📡 Gram イベントハンドラー"]
             MessageResolverHandler["🔄 メッセージリゾルバーハンドラー"]
         end
     end
@@ -207,7 +208,7 @@ graph TB
             
             subgraph "メッセージリゾルバー"
                 EmbeddingResolver["🤖 埋め込み<br/>リゾルバー<br/>(OpenAI)"]
-                JiebaResolver["📚 Jieba<br/>リゾルバー<br/>(中国語分割)"]
+                JiebaResolver["📚 Jieba<br/>リゾルバー<br/>（中国語分割）"]
                 LinkResolver["🔗 リンク<br/>リゾルバー"]
                 MediaResolver["📸 メディア<br/>リゾルバー"]
                 UserResolver["👤 ユーザー<br/>リゾルバー"]
@@ -220,16 +221,16 @@ graph TB
         Drizzle["Drizzle ORM"]
     end
 
-    subgraph "📡 外部API"
+    subgraph "📡 外部 API"
         TelegramAPI["Telegram API<br/>(gram.js)"]
         OpenAI["OpenAI API<br/>ベクトル埋め込み"]
     end
 
-    %% WebSocketイベントフロー
+    %% WebSocket イベントフロー
     Frontend -.->|"WsEventToServer<br/>• auth:login<br/>• message:query<br/>• dialog:fetch"| WS
     WS -.->|"WsEventToClient<br/>• message:data<br/>• auth:status<br/>• storage:progress"| Frontend
     
-    Electron -.->|"WebSocketイベント"| WS
+    Electron -.->|"WebSocket イベント"| WS
     WS -.->|"リアルタイム更新"| Electron
 
     %% サーバーレイヤー
@@ -269,7 +270,7 @@ graph TB
     StorageService --> Drizzle
     Drizzle --> DB
 
-    %% 外部API
+    %% 外部 API
     AuthService --> TelegramAPI
     MessageService --> TelegramAPI
     DialogService --> TelegramAPI
@@ -307,28 +308,28 @@ graph TB
 
 ### イベント駆動アーキテクチャの概要
 
-- **🎯 CoreContext - 中央イベントバス**: EventEmitter3を使用してすべてのイベントを管理するシステムの中心
-  - **ToCoreEvent**: コアシステムに送信されるイベント（auth:login、message:queryなど）
-  - **FromCoreEvent**: コアシステムから発行されるイベント（message:data、auth:statusなど）
+- **🎯 CoreContext - 中央イベントバス**: EventEmitter3 を使用してすべてのイベントを管理するシステムの中心
+  - **ToCoreEvent**: コアシステムに送信されるイベント（auth:login、message:query など）
+  - **FromCoreEvent**: コアシステムから発行されるイベント（message:data、auth:status など）
   - **イベントラッピング**: すべてのイベントの自動エラー処理とロギング
-  - **セッション管理**: 各クライアントセッションに独自のCoreContextインスタンス
+  - **セッション管理**: 各クライアントセッションに独自の CoreContext インスタンス
 
-- **🌐 WebSocketイベントブリッジ**: リアルタイム双方向通信レイヤー
+- **🌐 WebSocket イベントブリッジ**: リアルタイム双方向通信レイヤー
   - **イベント登録**: クライアントが受信したい特定のイベントを登録
-  - **イベント転送**: フロントエンドとCoreContext間でイベントをシームレスに転送
+  - **イベント転送**: フロントエンドと CoreContext 間でイベントをシームレスに転送
   - **セッション永続性**: 接続全体でクライアント状態とイベントリスナーを維持
 
 - **🔄 メッセージ処理パイプライン**: 複数のリゾルバーを通じたストリームベースのメッセージ処理
-  - **埋め込みリゾルバー**: セマンティック検索のためにOpenAIを使用してベクトル埋め込みを生成
-  - **Jiebaリゾルバー**: より良い検索機能のための中国語単語分割
+  - **埋め込みリゾルバー**: セマンティック検索のために OpenAI を使用してベクトル埋め込みを生成
+  - **Jieba リゾルバー**: より良い検索機能のための中国語単語分割
   - **リンク/メディア/ユーザーリゾルバー**: さまざまなメッセージコンテンツタイプを抽出して処理
 
 - **📡 イベントフロー**:
-  1. フロントエンドがWebSocket経由でイベントを発行（例: `auth:login`、`message:query`）
-  2. サーバーが適切なCoreContextインスタンスにイベントを転送
+  1. フロントエンドが WebSocket 経由でイベントを発行（例：`auth:login`、`message:query`）
+  2. サーバーが適切な CoreContext インスタンスにイベントを転送
   3. イベントハンドラーがイベントを処理し、対応するサービスを呼び出す
-  4. サービスがCoreContext経由で結果イベントを発行
-  5. WebSocketがリアルタイム更新のためにフロントエンドにイベントを転送
+  4. サービスが CoreContext 経由で結果イベントを発行
+  5. WebSocket がリアルタイム更新のためにフロントエンドにイベントを転送
 
 ## 🚀 アクティビティ
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -37,27 +37,63 @@
 
 ## 🚀 クイックスタート
 
-### 使用 Docker イメージ
+### ランタイム環境変数
 
-1. Docker イメージを実行
+コンテナを起動する前に、以下の環境変数を設定してください。
+
+| 変数 | 必須 | 説明 |
+| --- | --- | --- |
+| `TELEGRAM_API_ID` | ✅ | [my.telegram.org](https://my.telegram.org/apps) で取得した Telegram アプリ ID。 |
+| `TELEGRAM_API_HASH` | ✅ | 同じページで取得できる Telegram アプリ Hash。 |
+| `DATABASE_URL` | ✅ | サーバーとマイグレーションが利用する PostgreSQL 接続文字列。 |
+| `EMBEDDING_API_KEY` | ✅ | 埋め込みプロバイダーの API キー（OpenAI、Ollama など）。 |
+| `EMBEDDING_BASE_URL` | 任意 | 自前ホストや互換プロバイダー向けの API ベース URL。 |
+| `EMBEDDING_PROVIDER` | 任意 | 埋め込みプロバイダーを上書き（`openai` または `ollama`）。 |
+| `EMBEDDING_MODEL` | 任意 | 使用する埋め込みモデル名を上書き。 |
+| `EMBEDDING_DIMENSION` | 任意 | 埋め込みベクトルの次元数を上書き（`1536`、`1024`、`768` など）。 |
+| `PGVECTOR_HOST_PORT` | 任意 | pgvector を外部公開するときのホスト側ポート（例: `15432`）。 |
+| `PGVECTOR_HOST_IP` | 任意 | ポート公開時にバインドするホスト IP（例: `127.0.0.1` のみで待ち受け）。 |
+
+### Docker イメージから起動
+
+1. 必要な環境変数を指定してイメージを実行します。
 
 ```bash
-docker run ghcr.io/groupultra/telegram-search:latest -d
+docker run -d --name telegram-search \
+  -p 3333:3333 \
+  -e TELEGRAM_API_ID=123456 \
+  -e TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef \
+  -e DATABASE_URL=postgresql://postgres:123456@<postgres-host>:5432/postgres \
+  -e EMBEDDING_API_KEY=sk-xxxx \
+  -e EMBEDDING_BASE_URL=https://api.openai.com/v1 \
+  ghcr.io/groupultra/telegram-search:latest
 ```
+
+`<postgres-host>` には利用したい PostgreSQL のホスト名または IP アドレスを指定してください。
 
 2. http://localhost:3333 にアクセスして検索インターフェースを開きます。
 
-### 使用 Docker Compose
+### Docker Compose で起動
 
-1. リポジトリをクローン
+1. リポジトリをクローンします。
 
-2. docker compose を実行してすべてのサービスを起動します。
+2. ルートディレクトリに `.env` ファイルを作成し、上記の環境変数（必要なものだけ）を記載します。
+
+3. docker compose を実行してすべてのサービスを起動します。
 
 ```bash
 docker compose up -d
 ```
 
-3. http://localhost:3333 にアクセスして検索インターフェースを開きます。
+4. http://localhost:3333 にアクセスして検索インターフェースを開きます。
+
+5. pgvector のポートを外部公開したい場合は、起動時に `PGVECTOR_HOST_PORT` を指定してください。
+
+```bash
+PGVECTOR_HOST_PORT=15432 docker compose up -d
+```
+
+   特定のインターフェースだけで待ち受けたい場合は `PGVECTOR_HOST_IP=127.0.0.1` も併せて指定します。
 
 ## 💻 開発ガイド
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "bump": "bumpp",
     "bump:deps": "taze -I -f -w -r",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "tsx scripts/db.ts migrate",
-    "db:push": "tsx scripts/db.ts push",
     "db:kit": "tsx scripts/db.ts",
     "postinstall": "pnpm run packages:build"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "vitest",
     "lint": "eslint --cache .",
     "lint:fix": "eslint --cache . --fix",
-    "typecheck": "tsc --noEmit && pnpm -r --parallel typecheck",
+    "typecheck": "pnpm run packages:build && tsc --noEmit && pnpm -r --parallel typecheck",
     "bump": "bumpp",
     "bump:deps": "taze -I -f -w -r",
     "db:generate": "drizzle-kit generate",

--- a/packages/client/src/adapters/core-bridge.ts
+++ b/packages/client/src/adapters/core-bridge.ts
@@ -46,7 +46,7 @@ export const useCoreBridgeStore = defineStore('core-bridge', () => {
       config.api.telegram.apiHash ||= import.meta.env.VITE_TELEGRAM_APP_HASH
 
       ctx = createCoreInstance(config)
-      initDrizzle(logger, config, undefined, { debuggerWebSocketUrl: import.meta.env.VITE_DB_DEBUGGER_WS_URL })
+      initDrizzle(logger, config, { debuggerWebSocketUrl: import.meta.env.VITE_DB_DEBUGGER_WS_URL, isDatabaseDebugMode: import.meta.env.VITE_DB_DEBUG })
     }
 
     return ctx

--- a/packages/client/src/adapters/core-bridge.ts
+++ b/packages/client/src/adapters/core-bridge.ts
@@ -46,7 +46,10 @@ export const useCoreBridgeStore = defineStore('core-bridge', () => {
       config.api.telegram.apiHash ||= import.meta.env.VITE_TELEGRAM_APP_HASH
 
       ctx = createCoreInstance(config)
-      initDrizzle(logger, config, { debuggerWebSocketUrl: import.meta.env.VITE_DB_DEBUGGER_WS_URL, isDatabaseDebugMode: import.meta.env.VITE_DB_DEBUG })
+      initDrizzle(logger, config, {
+        debuggerWebSocketUrl: import.meta.env.VITE_DB_DEBUGGER_WS_URL as string,
+        isDatabaseDebugMode: import.meta.env.VITE_DB_DEBUG === 'true',
+      })
     }
 
     return ctx

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -52,8 +52,7 @@ export async function initConfig() {
     throw new Error('Failed to validate config')
   }
 
-  const runtimeOverrides = buildRuntimeOverrides(validatedConfig.output)
-  const runtimeConfig = defu(runtimeOverrides, validatedConfig.output) as Config
+  const runtimeConfig = applyRuntimeOverrides(validatedConfig.output)
 
   config = runtimeConfig
 
@@ -61,41 +60,29 @@ export async function initConfig() {
   return config
 }
 
-type PartialDeep<T> = {
-  [K in keyof T]?: T[K] extends Record<string, unknown> ? PartialDeep<T[K]> : T[K]
-}
-
-function buildRuntimeOverrides(baseConfig: Config): PartialDeep<Config> {
-  const overrides: PartialDeep<Config> = {
+function applyRuntimeOverrides(baseConfig: Config): Config {
+  const runtimeConfig: Config = {
+    ...baseConfig,
     database: {
-      url: flags.dbUrl || getDatabaseDSN(baseConfig),
+      ...baseConfig.database,
     },
+    api: baseConfig.api
+      ? {
+          ...baseConfig.api,
+        }
+      : undefined,
   }
 
-  const ensureApiOverrides = (): NonNullable<PartialDeep<Config>['api']> => {
-    if (!overrides.api) {
-      overrides.api = {}
+  runtimeConfig.database.url = flags.dbUrl || runtimeConfig.database.url || getDatabaseDSN(runtimeConfig)
+
+  if (flags.telegramApiId || flags.telegramApiHash) {
+    runtimeConfig.api = runtimeConfig.api || {}
+    const currentTelegram = runtimeConfig.api.telegram || {}
+    runtimeConfig.api.telegram = {
+      ...currentTelegram,
+      apiId: flags.telegramApiId || currentTelegram.apiId,
+      apiHash: flags.telegramApiHash || currentTelegram.apiHash,
     }
-
-    return overrides.api as NonNullable<PartialDeep<Config>['api']>
-  }
-
-  if (
-    typeof flags.telegramApiId === 'string'
-    || typeof flags.telegramApiHash === 'string'
-  ) {
-    const apiOverrides = ensureApiOverrides()
-    const telegramOverrides: NonNullable<typeof apiOverrides['telegram']> = {}
-
-    if (typeof flags.telegramApiId === 'string') {
-      telegramOverrides.apiId = flags.telegramApiId
-    }
-
-    if (typeof flags.telegramApiHash === 'string') {
-      telegramOverrides.apiHash = flags.telegramApiHash
-    }
-
-    apiOverrides.telegram = telegramOverrides
   }
 
   if (
@@ -105,33 +92,19 @@ function buildRuntimeOverrides(baseConfig: Config): PartialDeep<Config> {
     || typeof flags.embeddingApiKey === 'string'
     || typeof flags.embeddingApiBase === 'string'
   ) {
-    const apiOverrides = ensureApiOverrides()
-    const embeddingOverrides: NonNullable<typeof apiOverrides['embedding']> = {}
-
-    if (flags.embeddingProvider) {
-      embeddingOverrides.provider = flags.embeddingProvider
+    runtimeConfig.api = runtimeConfig.api || {}
+    const currentEmbedding = runtimeConfig.api.embedding || {}
+    runtimeConfig.api.embedding = {
+      ...currentEmbedding,
+      provider: flags.embeddingProvider || currentEmbedding.provider,
+      model: flags.embeddingModel || currentEmbedding.model,
+      dimension: flags.embeddingDimension || currentEmbedding.dimension,
+      apiKey: flags.embeddingApiKey || currentEmbedding.apiKey,
+      apiBase: flags.embeddingApiBase || currentEmbedding.apiBase,
     }
-
-    if (typeof flags.embeddingModel === 'string') {
-      embeddingOverrides.model = flags.embeddingModel
-    }
-
-    if (typeof flags.embeddingDimension === 'number') {
-      embeddingOverrides.dimension = flags.embeddingDimension
-    }
-
-    if (typeof flags.embeddingApiKey === 'string') {
-      embeddingOverrides.apiKey = flags.embeddingApiKey
-    }
-
-    if (typeof flags.embeddingApiBase === 'string') {
-      embeddingOverrides.apiBase = flags.embeddingApiBase
-    }
-
-    apiOverrides.embedding = embeddingOverrides
   }
 
-  return overrides
+  return runtimeConfig
 }
 
 export async function updateConfig(newConfig: Partial<Config>) {

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -30,8 +30,8 @@ function validateAndMergeConfig(newConfig: Partial<Config>, baseConfig?: Config)
   return validatedConfig.output
 }
 
-function applyTelegramOverrides(config: Config, flags: RuntimeFlags): void {
-  if (flags.telegramApiId || flags.telegramApiHash) {
+function applyTelegramOverrides(config: Config, flags?: RuntimeFlags): void {
+  if (flags?.telegramApiId || flags?.telegramApiHash) {
     config.api = config.api || {}
     const currentTelegram = config.api.telegram || {}
     config.api.telegram = {
@@ -42,13 +42,13 @@ function applyTelegramOverrides(config: Config, flags: RuntimeFlags): void {
   }
 }
 
-function applyEmbeddingOverrides(config: Config, flags: RuntimeFlags): void {
+function applyEmbeddingOverrides(config: Config, flags?: RuntimeFlags): void {
   if (
-    flags.embeddingProvider
-    || flags.embeddingModel
-    || flags.embeddingDimension
-    || flags.embeddingApiKey
-    || flags.embeddingApiBase
+    flags?.embeddingProvider
+    || flags?.embeddingModel
+    || flags?.embeddingDimension
+    || flags?.embeddingApiKey
+    || flags?.embeddingApiBase
   ) {
     config.api = config.api || {}
     const currentEmbedding = config.api.embedding || {}
@@ -63,7 +63,7 @@ function applyEmbeddingOverrides(config: Config, flags: RuntimeFlags): void {
   }
 }
 
-export async function initConfig(flags: RuntimeFlags) {
+export async function initConfig(flags?: RuntimeFlags) {
   if (isBrowser()) {
     const configStorage = useLocalStorage(CONFIG_STORAGE_KEY, generateDefaultConfig())
 
@@ -98,7 +98,7 @@ export async function initConfig(flags: RuntimeFlags) {
   return config
 }
 
-function applyRuntimeOverrides(baseConfig: Config, flags: RuntimeFlags): Config {
+function applyRuntimeOverrides(baseConfig: Config, flags?: RuntimeFlags): Config {
   const runtimeConfig: Config = {
     ...baseConfig,
     database: { ...baseConfig.database },
@@ -109,7 +109,7 @@ function applyRuntimeOverrides(baseConfig: Config, flags: RuntimeFlags): Config 
   }
 
   // Apply database URL override
-  runtimeConfig.database.url = flags.dbUrl || runtimeConfig.database.url || getDatabaseDSN(runtimeConfig)
+  runtimeConfig.database.url = flags?.dbUrl || runtimeConfig.database.url || getDatabaseDSN(runtimeConfig)
 
   // Apply API overrides
   applyTelegramOverrides(runtimeConfig, flags)

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -1,4 +1,5 @@
 import type { Config } from './config-schema'
+import type { RuntimeFlags } from './flags'
 
 import { useLogger } from '@unbird/logg'
 import { isBrowser } from '@unbird/logg/utils'
@@ -7,7 +8,6 @@ import defu from 'defu'
 import { safeParse } from 'valibot'
 
 import { configSchema, generateDefaultConfig } from './config-schema'
-import { flags } from './flags'
 
 let config: Config
 const logger = useLogger('common:config')
@@ -18,17 +18,62 @@ export function getDatabaseDSN(config: Config): string {
   return database.url || `postgres://${database.user}:${database.password}@${database.host}:${database.port}/${database.database}`
 }
 
-export async function initConfig() {
+function validateAndMergeConfig(newConfig: Partial<Config>, baseConfig?: Config): Config {
+  const mergedConfig = defu({}, newConfig, baseConfig || generateDefaultConfig())
+  const validatedConfig = safeParse(configSchema, mergedConfig)
+
+  if (!validatedConfig.success) {
+    logger.withFields({ issues: validatedConfig.issues }).error('Failed to validate config')
+    throw new Error('Failed to validate config')
+  }
+
+  return validatedConfig.output
+}
+
+function applyTelegramOverrides(config: Config, flags: RuntimeFlags): void {
+  if (flags.telegramApiId || flags.telegramApiHash) {
+    config.api = config.api || {}
+    const currentTelegram = config.api.telegram || {}
+    config.api.telegram = {
+      ...currentTelegram,
+      ...(flags.telegramApiId && { apiId: flags.telegramApiId }),
+      ...(flags.telegramApiHash && { apiHash: flags.telegramApiHash }),
+    }
+  }
+}
+
+function applyEmbeddingOverrides(config: Config, flags: RuntimeFlags): void {
+  if (
+    flags.embeddingProvider
+    || flags.embeddingModel
+    || flags.embeddingDimension
+    || flags.embeddingApiKey
+    || flags.embeddingApiBase
+  ) {
+    config.api = config.api || {}
+    const currentEmbedding = config.api.embedding || {}
+    config.api.embedding = {
+      ...currentEmbedding,
+      ...(flags.embeddingProvider && { provider: flags.embeddingProvider }),
+      ...(flags.embeddingModel && { model: flags.embeddingModel }),
+      ...(flags.embeddingDimension && { dimension: flags.embeddingDimension }),
+      ...(flags.embeddingApiKey && { apiKey: flags.embeddingApiKey }),
+      ...(flags.embeddingApiBase && { apiBase: flags.embeddingApiBase }),
+    }
+  }
+}
+
+export async function initConfig(flags: RuntimeFlags) {
   if (isBrowser()) {
     const configStorage = useLocalStorage(CONFIG_STORAGE_KEY, generateDefaultConfig())
 
     const savedConfig = configStorage.value
     if (savedConfig) {
-      const validatedConfig = safeParse(configSchema, savedConfig)
-      if (validatedConfig.success) {
-        config = validatedConfig.output
+      try {
+        config = validateAndMergeConfig(savedConfig)
         return config
       }
+      catch {}
     }
 
     config = generateDefaultConfig()
@@ -44,15 +89,8 @@ export async function initConfig() {
   const configData = readFileSync(configPath, 'utf-8')
   const configParsedData = parse(configData)
 
-  const mergedConfig = defu({}, configParsedData, generateDefaultConfig())
-  const validatedConfig = safeParse(configSchema, mergedConfig)
-
-  if (!validatedConfig.success) {
-    logger.withFields({ issues: validatedConfig.issues }).error('Failed to validate config')
-    throw new Error('Failed to validate config')
-  }
-
-  const runtimeConfig = applyRuntimeOverrides(validatedConfig.output)
+  const validatedConfig = validateAndMergeConfig(configParsedData)
+  const runtimeConfig = applyRuntimeOverrides(validatedConfig, flags)
 
   config = runtimeConfig
 
@@ -60,49 +98,22 @@ export async function initConfig() {
   return config
 }
 
-function applyRuntimeOverrides(baseConfig: Config): Config {
+function applyRuntimeOverrides(baseConfig: Config, flags: RuntimeFlags): Config {
   const runtimeConfig: Config = {
     ...baseConfig,
-    database: {
-      ...baseConfig.database,
-    },
-    api: baseConfig.api
-      ? {
-          ...baseConfig.api,
-        }
-      : undefined,
+    database: { ...baseConfig.database },
   }
 
+  if (baseConfig.api) {
+    runtimeConfig.api = { ...baseConfig.api }
+  }
+
+  // Apply database URL override
   runtimeConfig.database.url = flags.dbUrl || runtimeConfig.database.url || getDatabaseDSN(runtimeConfig)
 
-  if (flags.telegramApiId || flags.telegramApiHash) {
-    runtimeConfig.api = runtimeConfig.api || {}
-    const currentTelegram = runtimeConfig.api.telegram || {}
-    runtimeConfig.api.telegram = {
-      ...currentTelegram,
-      apiId: flags.telegramApiId || currentTelegram.apiId,
-      apiHash: flags.telegramApiHash || currentTelegram.apiHash,
-    }
-  }
-
-  if (
-    flags.embeddingProvider
-    || typeof flags.embeddingModel === 'string'
-    || typeof flags.embeddingDimension === 'number'
-    || typeof flags.embeddingApiKey === 'string'
-    || typeof flags.embeddingApiBase === 'string'
-  ) {
-    runtimeConfig.api = runtimeConfig.api || {}
-    const currentEmbedding = runtimeConfig.api.embedding || {}
-    runtimeConfig.api.embedding = {
-      ...currentEmbedding,
-      provider: flags.embeddingProvider || currentEmbedding.provider,
-      model: flags.embeddingModel || currentEmbedding.model,
-      dimension: flags.embeddingDimension || currentEmbedding.dimension,
-      apiKey: flags.embeddingApiKey || currentEmbedding.apiKey,
-      apiBase: flags.embeddingApiBase || currentEmbedding.apiBase,
-    }
-  }
+  // Apply API overrides
+  applyTelegramOverrides(runtimeConfig, flags)
+  applyEmbeddingOverrides(runtimeConfig, flags)
 
   return runtimeConfig
 }
@@ -111,18 +122,11 @@ export async function updateConfig(newConfig: Partial<Config>) {
   if (isBrowser()) {
     const configStorage = useLocalStorage(CONFIG_STORAGE_KEY, generateDefaultConfig())
 
-    const mergedConfig = defu({}, newConfig, config)
-    const validatedConfig = safeParse(configSchema, mergedConfig)
+    const validatedConfig = validateAndMergeConfig(newConfig, config)
 
-    if (!validatedConfig.success) {
-      logger.withFields({ issues: validatedConfig.issues }).error('Failed to validate config')
-      throw new Error('Failed to validate config')
-    }
+    logger.withFields({ config: validatedConfig }).log('Updating config')
 
-    logger.withFields({ config: validatedConfig.output }).log('Updating config')
-
-    config = validatedConfig.output
-
+    config = validatedConfig
     configStorage.value = config
 
     return config
@@ -134,20 +138,13 @@ export async function updateConfig(newConfig: Partial<Config>) {
 
   const configPath = await useConfigPath()
 
-  const mergedConfig = defu({}, newConfig, config)
-  const validatedConfig = safeParse(configSchema, mergedConfig)
+  const validatedConfig = validateAndMergeConfig(newConfig, config)
+  validatedConfig.database.url = getDatabaseDSN(validatedConfig)
 
-  if (!validatedConfig.success) {
-    logger.withFields({ issues: validatedConfig.issues }).error('Failed to validate config')
-    throw new Error('Failed to validate config')
-  }
+  logger.withFields({ config: validatedConfig }).log('Updating config')
+  writeFileSync(configPath, stringify(validatedConfig))
 
-  validatedConfig.output.database.url = getDatabaseDSN(validatedConfig.output)
-
-  logger.withFields({ config: validatedConfig.output }).log('Updating config')
-  writeFileSync(configPath, stringify(validatedConfig.output))
-
-  config = validatedConfig.output
+  config = validatedConfig
   return config
 }
 

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -52,12 +52,86 @@ export async function initConfig() {
     throw new Error('Failed to validate config')
   }
 
-  validatedConfig.output.database.url = flags.dbUrl || getDatabaseDSN(validatedConfig.output)
+  const runtimeOverrides = buildRuntimeOverrides(validatedConfig.output)
+  const runtimeConfig = defu(runtimeOverrides, validatedConfig.output) as Config
 
-  config = validatedConfig.output
+  config = runtimeConfig
 
   logger.withFields(config).log('Config loaded')
   return config
+}
+
+type PartialDeep<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown> ? PartialDeep<T[K]> : T[K]
+}
+
+function buildRuntimeOverrides(baseConfig: Config): PartialDeep<Config> {
+  const overrides: PartialDeep<Config> = {
+    database: {
+      url: flags.dbUrl || getDatabaseDSN(baseConfig),
+    },
+  }
+
+  const ensureApiOverrides = (): NonNullable<PartialDeep<Config>['api']> => {
+    if (!overrides.api) {
+      overrides.api = {}
+    }
+
+    return overrides.api as NonNullable<PartialDeep<Config>['api']>
+  }
+
+  if (
+    typeof flags.telegramApiId === 'string'
+    || typeof flags.telegramApiHash === 'string'
+  ) {
+    const apiOverrides = ensureApiOverrides()
+    const telegramOverrides: NonNullable<typeof apiOverrides['telegram']> = {}
+
+    if (typeof flags.telegramApiId === 'string') {
+      telegramOverrides.apiId = flags.telegramApiId
+    }
+
+    if (typeof flags.telegramApiHash === 'string') {
+      telegramOverrides.apiHash = flags.telegramApiHash
+    }
+
+    apiOverrides.telegram = telegramOverrides
+  }
+
+  if (
+    flags.embeddingProvider
+    || typeof flags.embeddingModel === 'string'
+    || typeof flags.embeddingDimension === 'number'
+    || typeof flags.embeddingApiKey === 'string'
+    || typeof flags.embeddingApiBase === 'string'
+  ) {
+    const apiOverrides = ensureApiOverrides()
+    const embeddingOverrides: NonNullable<typeof apiOverrides['embedding']> = {}
+
+    if (flags.embeddingProvider) {
+      embeddingOverrides.provider = flags.embeddingProvider
+    }
+
+    if (typeof flags.embeddingModel === 'string') {
+      embeddingOverrides.model = flags.embeddingModel
+    }
+
+    if (typeof flags.embeddingDimension === 'number') {
+      embeddingOverrides.dimension = flags.embeddingDimension
+    }
+
+    if (typeof flags.embeddingApiKey === 'string') {
+      embeddingOverrides.apiKey = flags.embeddingApiKey
+    }
+
+    if (typeof flags.embeddingApiBase === 'string') {
+      embeddingOverrides.apiBase = flags.embeddingApiBase
+    }
+
+    apiOverrides.embedding = embeddingOverrides
+  }
+
+  return overrides
 }
 
 export async function updateConfig(newConfig: Partial<Config>) {

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -109,6 +109,7 @@ function applyRuntimeOverrides(baseConfig: Config, flags?: RuntimeFlags): Config
   }
 
   // Apply database URL override
+  runtimeConfig.database.type = flags?.dbProvider || runtimeConfig.database.type
   runtimeConfig.database.url = flags?.dbUrl || runtimeConfig.database.url || getDatabaseDSN(runtimeConfig)
 
   // Apply API overrides

--- a/packages/common/src/flags.ts
+++ b/packages/common/src/flags.ts
@@ -1,6 +1,27 @@
 import { LoggerFormat, LoggerLevel } from '@unbird/logg'
 
-export const flags = {
+import { EmbeddingDimension, EmbeddingProvider } from './config-schema'
+
+export interface RuntimeFlags {
+  logLevel: LoggerLevel
+  logFormat: LoggerFormat
+
+  isDebugMode: boolean
+  isDatabaseDebugMode: boolean
+
+  dbUrl: string
+
+  telegramApiId?: string
+  telegramApiHash?: string
+
+  embeddingProvider?: EmbeddingProvider
+  embeddingModel?: string
+  embeddingDimension?: number
+  embeddingApiKey?: string
+  embeddingApiBase?: string
+}
+
+export const flags: RuntimeFlags = {
   logLevel: LoggerLevel.Verbose,
   logFormat: LoggerFormat.Pretty,
 
@@ -10,13 +31,22 @@ export const flags = {
   dbUrl: '',
 }
 
-export function parseEnvFlags(env: Record<string, string>) {
-  for (const [key, value] of Object.entries(env)) {
-    const lowerKey = key.toLowerCase()
-    const lowerValue = value.toLowerCase()
+interface EnvParser {
+  readonly keys: ReadonlyArray<string>
+  readonly parse: (value: string) => void
+}
 
-    if (lowerKey === 'log_level') {
-      switch (lowerValue) {
+const embeddingProvidersByName: Record<string, EmbeddingProvider> = {
+  [EmbeddingProvider.OPENAI]: EmbeddingProvider.OPENAI,
+  [EmbeddingProvider.OLLAMA]: EmbeddingProvider.OLLAMA,
+}
+
+const envParsers: ReadonlyArray<EnvParser> = [
+  {
+    keys: ['log_level'],
+    parse(value: string) {
+      const normalizedValue = value.trim().toLowerCase()
+      switch (normalizedValue) {
         case 'debug':
           flags.logLevel = LoggerLevel.Debug
           flags.isDebugMode = true
@@ -25,14 +55,88 @@ export function parseEnvFlags(env: Record<string, string>) {
           flags.logLevel = LoggerLevel.Verbose
           break
       }
-    }
-
-    if (lowerKey === 'database_debug') {
-      flags.isDatabaseDebugMode = lowerValue === 'true'
-    }
-
-    if (lowerKey === 'database_url') {
+    },
+  },
+  {
+    keys: ['database_debug'],
+    parse(value: string) {
+      flags.isDatabaseDebugMode = value.trim().toLowerCase() === 'true'
+    },
+  },
+  {
+    keys: ['database_url'],
+    parse(value: string) {
       flags.dbUrl = value
+    },
+  },
+  {
+    keys: ['telegram_api_id', 'tg_api_id'],
+    parse(value: string) {
+      flags.telegramApiId = value
+    },
+  },
+  {
+    keys: ['telegram_api_hash', 'tg_api_hash', 'tg_api_key', 'telegram_api_key'],
+    parse(value: string) {
+      flags.telegramApiHash = value
+    },
+  },
+  {
+    keys: ['embedding_provider'],
+    parse(value: string) {
+      const normalizedValue = value.trim().toLowerCase()
+      const provider = embeddingProvidersByName[normalizedValue]
+      if (provider) {
+        flags.embeddingProvider = provider
+      }
+    },
+  },
+  {
+    keys: ['embedding_model'],
+    parse(value: string) {
+      flags.embeddingModel = value
+    },
+  },
+  {
+    keys: ['embedding_dimension'],
+    parse(value: string) {
+      const parsed = Number.parseInt(value, 10)
+      if (Number.isInteger(parsed) && Object.values(EmbeddingDimension).includes(parsed as EmbeddingDimension)) {
+        flags.embeddingDimension = parsed
+      }
+    },
+  },
+  {
+    keys: ['embedding_api_key', 'embedding_key'],
+    parse(value: string) {
+      flags.embeddingApiKey = value
+    },
+  },
+  {
+    keys: ['embedding_api_base', 'embedding_base_url', 'embedding_baseurl', 'embedding_base', 'baseurl', 'base_url'],
+    parse(value: string) {
+      flags.embeddingApiBase = value
+    },
+  },
+]
+
+export function parseEnvFlags(env: Record<string, string>) {
+  const normalizedEnv = new Map<string, string>()
+
+  for (const [key, value] of Object.entries(env)) {
+    normalizedEnv.set(key.toLowerCase(), value)
+  }
+
+  for (const parser of envParsers) {
+    for (const key of parser.keys) {
+      const rawValue = normalizedEnv.get(key)
+
+      if (typeof rawValue === 'undefined') {
+        continue
+      }
+
+      parser.parse(rawValue)
+      break
     }
   }
 

--- a/packages/common/src/flags.ts
+++ b/packages/common/src/flags.ts
@@ -38,42 +38,23 @@ const EMBEDDING_PROVIDER_ALIASES: Readonly<Record<string, EmbeddingProvider>> = 
   ollama: EmbeddingProvider.OLLAMA,
 }
 
-const TELEGRAM_ID_KEYS: ReadonlyArray<string> = ['TELEGRAM_API_ID', 'TG_API_ID']
-const TELEGRAM_HASH_KEYS: ReadonlyArray<string> = ['TELEGRAM_API_HASH', 'TG_API_HASH', 'TG_API_KEY', 'TELEGRAM_API_KEY']
-const EMBEDDING_PROVIDER_KEYS: ReadonlyArray<string> = ['EMBEDDING_PROVIDER']
-const EMBEDDING_MODEL_KEYS: ReadonlyArray<string> = ['EMBEDDING_MODEL']
-const EMBEDDING_DIMENSION_KEYS: ReadonlyArray<string> = ['EMBEDDING_DIMENSION']
-const EMBEDDING_KEY_KEYS: ReadonlyArray<string> = ['EMBEDDING_API_KEY', 'EMBEDDING_KEY']
-const EMBEDDING_BASE_KEYS: ReadonlyArray<string> = [
-  'EMBEDDING_API_BASE',
-  'EMBEDDING_BASE_URL',
-  'EMBEDDING_BASEURL',
-  'EMBEDDING_BASE',
-  'BASEURL',
-  'BASE_URL',
-]
-
-function readEnvValue(keys: ReadonlyArray<string>, env: Record<string, string | undefined>): string | undefined {
-  for (const key of keys) {
-    const value = env[key] ?? env[key.toLowerCase()] ?? env[key.toUpperCase()]
-    if (typeof value === 'string') {
-      const trimmed = value.trim()
-      if (trimmed.length > 0) {
-        return trimmed
-      }
-    }
+function readEnvValue(key: string, env: Record<string, string | undefined>): string | undefined {
+  const candidate = env[key] ?? env[key.toLowerCase()] ?? env[key.toUpperCase()]
+  if (typeof candidate !== 'string') {
+    return undefined
   }
 
-  return undefined
+  const trimmed = candidate.trim()
+  return trimmed.length > 0 ? trimmed : undefined
 }
 
 function readBooleanEnv(key: string, env: Record<string, string | undefined>): boolean {
-  const value = readEnvValue([key], env)
+  const value = readEnvValue(key, env)
   return value ? TRUE_VALUES.has(value.toLowerCase()) : false
 }
 
-function readIntegerEnv(keys: ReadonlyArray<string>, env: Record<string, string | undefined>): number | undefined {
-  const rawValue = readEnvValue(keys, env)
+function readIntegerEnv(key: string, env: Record<string, string | undefined>): number | undefined {
+  const rawValue = readEnvValue(key, env)
   if (!rawValue) {
     return undefined
   }
@@ -87,7 +68,7 @@ function readIntegerEnv(keys: ReadonlyArray<string>, env: Record<string, string 
 }
 
 export function parseEnvFlags(env: Record<string, string | undefined>): void {
-  const logLevelValue = readEnvValue(['LOG_LEVEL'], env)
+  const logLevelValue = readEnvValue('LOG_LEVEL', env)
   if (logLevelValue) {
     const normalized = logLevelValue.toLowerCase()
     switch (normalized) {
@@ -104,22 +85,22 @@ export function parseEnvFlags(env: Record<string, string | undefined>): void {
 
   flags.isDatabaseDebugMode = readBooleanEnv('DATABASE_DEBUG', env)
 
-  const dbUrlValue = readEnvValue(['DATABASE_URL'], env)
+  const dbUrlValue = readEnvValue('DATABASE_URL', env)
   if (dbUrlValue) {
     flags.dbUrl = dbUrlValue
   }
 
-  const telegramId = readEnvValue(TELEGRAM_ID_KEYS, env)
+  const telegramId = readEnvValue('TELEGRAM_API_ID', env)
   if (telegramId) {
     flags.telegramApiId = telegramId
   }
 
-  const telegramHash = readEnvValue(TELEGRAM_HASH_KEYS, env)
+  const telegramHash = readEnvValue('TELEGRAM_API_HASH', env)
   if (telegramHash) {
     flags.telegramApiHash = telegramHash
   }
 
-  const embeddingProviderValue = readEnvValue(EMBEDDING_PROVIDER_KEYS, env)
+  const embeddingProviderValue = readEnvValue('EMBEDDING_PROVIDER', env)
   if (embeddingProviderValue) {
     const normalized = embeddingProviderValue.toLowerCase()
     const provider = EMBEDDING_PROVIDER_ALIASES[normalized]
@@ -128,12 +109,12 @@ export function parseEnvFlags(env: Record<string, string | undefined>): void {
     }
   }
 
-  const embeddingModelValue = readEnvValue(EMBEDDING_MODEL_KEYS, env)
+  const embeddingModelValue = readEnvValue('EMBEDDING_MODEL', env)
   if (embeddingModelValue) {
     flags.embeddingModel = embeddingModelValue
   }
 
-  const embeddingDimensionValue = readIntegerEnv(EMBEDDING_DIMENSION_KEYS, env)
+  const embeddingDimensionValue = readIntegerEnv('EMBEDDING_DIMENSION', env)
   if (
     typeof embeddingDimensionValue === 'number'
     && Object.values(EmbeddingDimension).includes(embeddingDimensionValue as EmbeddingDimension)
@@ -141,12 +122,12 @@ export function parseEnvFlags(env: Record<string, string | undefined>): void {
     flags.embeddingDimension = embeddingDimensionValue
   }
 
-  const embeddingKeyValue = readEnvValue(EMBEDDING_KEY_KEYS, env)
+  const embeddingKeyValue = readEnvValue('EMBEDDING_API_KEY', env)
   if (embeddingKeyValue) {
     flags.embeddingApiKey = embeddingKeyValue
   }
 
-  const embeddingBaseValue = readEnvValue(EMBEDDING_BASE_KEYS, env)
+  const embeddingBaseValue = readEnvValue('EMBEDDING_BASE_URL', env)
   if (embeddingBaseValue) {
     flags.embeddingApiBase = embeddingBaseValue
   }

--- a/packages/common/src/flags.ts
+++ b/packages/common/src/flags.ts
@@ -1,3 +1,5 @@
+import type { DatabaseType } from './config-schema'
+
 import { LoggerFormat, LoggerLevel } from '@unbird/logg'
 
 import { EmbeddingDimension, EmbeddingProvider } from './config-schema'
@@ -9,6 +11,7 @@ export interface RuntimeFlags {
   isDebugMode: boolean
   isDatabaseDebugMode: boolean
 
+  dbProvider?: DatabaseType
   dbUrl?: string
 
   telegramApiId?: string
@@ -91,6 +94,7 @@ export function parseEnvFlags(env: Record<string, string | undefined>): RuntimeF
 
   result.isDatabaseDebugMode = readBooleanEnv('DATABASE_DEBUG', env)
 
+  assignIfPresent(result, 'dbProvider', readEnvValue('DATABASE_TYPE', env))
   assignIfPresent(result, 'dbUrl', readEnvValue('DATABASE_URL', env))
   assignIfPresent(result, 'telegramApiId', readEnvValue('TELEGRAM_API_ID', env))
   assignIfPresent(result, 'telegramApiHash', readEnvValue('TELEGRAM_API_HASH', env))

--- a/packages/common/src/flags.ts
+++ b/packages/common/src/flags.ts
@@ -31,115 +31,123 @@ export const flags: RuntimeFlags = {
   dbUrl: '',
 }
 
-interface EnvParser {
-  readonly keys: ReadonlyArray<string>
-  readonly parse: (value: string) => void
+const TRUE_VALUES: ReadonlySet<string> = new Set(['1', 'true', 'yes'])
+
+const EMBEDDING_PROVIDER_ALIASES: Readonly<Record<string, EmbeddingProvider>> = {
+  openai: EmbeddingProvider.OPENAI,
+  ollama: EmbeddingProvider.OLLAMA,
 }
 
-const embeddingProvidersByName: Record<string, EmbeddingProvider> = {
-  [EmbeddingProvider.OPENAI]: EmbeddingProvider.OPENAI,
-  [EmbeddingProvider.OLLAMA]: EmbeddingProvider.OLLAMA,
-}
-
-const envParsers: ReadonlyArray<EnvParser> = [
-  {
-    keys: ['log_level'],
-    parse(value: string) {
-      const normalizedValue = value.trim().toLowerCase()
-      switch (normalizedValue) {
-        case 'debug':
-          flags.logLevel = LoggerLevel.Debug
-          flags.isDebugMode = true
-          break
-        case 'verbose':
-          flags.logLevel = LoggerLevel.Verbose
-          break
-      }
-    },
-  },
-  {
-    keys: ['database_debug'],
-    parse(value: string) {
-      flags.isDatabaseDebugMode = value.trim().toLowerCase() === 'true'
-    },
-  },
-  {
-    keys: ['database_url'],
-    parse(value: string) {
-      flags.dbUrl = value
-    },
-  },
-  {
-    keys: ['telegram_api_id', 'tg_api_id'],
-    parse(value: string) {
-      flags.telegramApiId = value
-    },
-  },
-  {
-    keys: ['telegram_api_hash', 'tg_api_hash', 'tg_api_key', 'telegram_api_key'],
-    parse(value: string) {
-      flags.telegramApiHash = value
-    },
-  },
-  {
-    keys: ['embedding_provider'],
-    parse(value: string) {
-      const normalizedValue = value.trim().toLowerCase()
-      const provider = embeddingProvidersByName[normalizedValue]
-      if (provider) {
-        flags.embeddingProvider = provider
-      }
-    },
-  },
-  {
-    keys: ['embedding_model'],
-    parse(value: string) {
-      flags.embeddingModel = value
-    },
-  },
-  {
-    keys: ['embedding_dimension'],
-    parse(value: string) {
-      const parsed = Number.parseInt(value, 10)
-      if (Number.isInteger(parsed) && Object.values(EmbeddingDimension).includes(parsed as EmbeddingDimension)) {
-        flags.embeddingDimension = parsed
-      }
-    },
-  },
-  {
-    keys: ['embedding_api_key', 'embedding_key'],
-    parse(value: string) {
-      flags.embeddingApiKey = value
-    },
-  },
-  {
-    keys: ['embedding_api_base', 'embedding_base_url', 'embedding_baseurl', 'embedding_base', 'baseurl', 'base_url'],
-    parse(value: string) {
-      flags.embeddingApiBase = value
-    },
-  },
+const TELEGRAM_ID_KEYS: ReadonlyArray<string> = ['TELEGRAM_API_ID', 'TG_API_ID']
+const TELEGRAM_HASH_KEYS: ReadonlyArray<string> = ['TELEGRAM_API_HASH', 'TG_API_HASH', 'TG_API_KEY', 'TELEGRAM_API_KEY']
+const EMBEDDING_PROVIDER_KEYS: ReadonlyArray<string> = ['EMBEDDING_PROVIDER']
+const EMBEDDING_MODEL_KEYS: ReadonlyArray<string> = ['EMBEDDING_MODEL']
+const EMBEDDING_DIMENSION_KEYS: ReadonlyArray<string> = ['EMBEDDING_DIMENSION']
+const EMBEDDING_KEY_KEYS: ReadonlyArray<string> = ['EMBEDDING_API_KEY', 'EMBEDDING_KEY']
+const EMBEDDING_BASE_KEYS: ReadonlyArray<string> = [
+  'EMBEDDING_API_BASE',
+  'EMBEDDING_BASE_URL',
+  'EMBEDDING_BASEURL',
+  'EMBEDDING_BASE',
+  'BASEURL',
+  'BASE_URL',
 ]
 
-export function parseEnvFlags(env: Record<string, string>) {
-  const normalizedEnv = new Map<string, string>()
-
-  for (const [key, value] of Object.entries(env)) {
-    normalizedEnv.set(key.toLowerCase(), value)
-  }
-
-  for (const parser of envParsers) {
-    for (const key of parser.keys) {
-      const rawValue = normalizedEnv.get(key)
-
-      if (typeof rawValue === 'undefined') {
-        continue
+function readEnvValue(keys: ReadonlyArray<string>, env: Record<string, string | undefined>): string | undefined {
+  for (const key of keys) {
+    const value = env[key] ?? env[key.toLowerCase()] ?? env[key.toUpperCase()]
+    if (typeof value === 'string') {
+      const trimmed = value.trim()
+      if (trimmed.length > 0) {
+        return trimmed
       }
-
-      parser.parse(rawValue)
-      break
     }
   }
 
-  // eslint-disable-next-line no-console
-  console.log('Flags parsed', flags)
+  return undefined
+}
+
+function readBooleanEnv(key: string, env: Record<string, string | undefined>): boolean {
+  const value = readEnvValue([key], env)
+  return value ? TRUE_VALUES.has(value.toLowerCase()) : false
+}
+
+function readIntegerEnv(keys: ReadonlyArray<string>, env: Record<string, string | undefined>): number | undefined {
+  const rawValue = readEnvValue(keys, env)
+  if (!rawValue) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(rawValue, 10)
+  if (Number.isInteger(parsed)) {
+    return parsed
+  }
+
+  return undefined
+}
+
+export function parseEnvFlags(env: Record<string, string | undefined>): void {
+  const logLevelValue = readEnvValue(['LOG_LEVEL'], env)
+  if (logLevelValue) {
+    const normalized = logLevelValue.toLowerCase()
+    switch (normalized) {
+      case 'debug':
+        flags.logLevel = LoggerLevel.Debug
+        flags.isDebugMode = true
+        break
+      case 'verbose':
+        flags.logLevel = LoggerLevel.Verbose
+        flags.isDebugMode = false
+        break
+    }
+  }
+
+  flags.isDatabaseDebugMode = readBooleanEnv('DATABASE_DEBUG', env)
+
+  const dbUrlValue = readEnvValue(['DATABASE_URL'], env)
+  if (dbUrlValue) {
+    flags.dbUrl = dbUrlValue
+  }
+
+  const telegramId = readEnvValue(TELEGRAM_ID_KEYS, env)
+  if (telegramId) {
+    flags.telegramApiId = telegramId
+  }
+
+  const telegramHash = readEnvValue(TELEGRAM_HASH_KEYS, env)
+  if (telegramHash) {
+    flags.telegramApiHash = telegramHash
+  }
+
+  const embeddingProviderValue = readEnvValue(EMBEDDING_PROVIDER_KEYS, env)
+  if (embeddingProviderValue) {
+    const normalized = embeddingProviderValue.toLowerCase()
+    const provider = EMBEDDING_PROVIDER_ALIASES[normalized]
+    if (provider) {
+      flags.embeddingProvider = provider
+    }
+  }
+
+  const embeddingModelValue = readEnvValue(EMBEDDING_MODEL_KEYS, env)
+  if (embeddingModelValue) {
+    flags.embeddingModel = embeddingModelValue
+  }
+
+  const embeddingDimensionValue = readIntegerEnv(EMBEDDING_DIMENSION_KEYS, env)
+  if (
+    typeof embeddingDimensionValue === 'number'
+    && Object.values(EmbeddingDimension).includes(embeddingDimensionValue as EmbeddingDimension)
+  ) {
+    flags.embeddingDimension = embeddingDimensionValue
+  }
+
+  const embeddingKeyValue = readEnvValue(EMBEDDING_KEY_KEYS, env)
+  if (embeddingKeyValue) {
+    flags.embeddingApiKey = embeddingKeyValue
+  }
+
+  const embeddingBaseValue = readEnvValue(EMBEDDING_BASE_KEYS, env)
+  if (embeddingBaseValue) {
+    flags.embeddingApiBase = embeddingBaseValue
+  }
 }

--- a/packages/common/src/flags.ts
+++ b/packages/common/src/flags.ts
@@ -117,5 +117,8 @@ export function parseEnvFlags(env: Record<string, string | undefined>): RuntimeF
   assignIfPresent(result, 'embeddingApiKey', readEnvValue('EMBEDDING_API_KEY', env))
   assignIfPresent(result, 'embeddingApiBase', readEnvValue('EMBEDDING_BASE_URL', env))
 
+  // eslint-disable-next-line no-console
+  console.log('Flags parsed', result)
+
   return result
 }

--- a/packages/common/src/flags.ts
+++ b/packages/common/src/flags.ts
@@ -9,7 +9,7 @@ export interface RuntimeFlags {
   isDebugMode: boolean
   isDatabaseDebugMode: boolean
 
-  dbUrl: string
+  dbUrl?: string
 
   telegramApiId?: string
   telegramApiHash?: string
@@ -21,14 +21,12 @@ export interface RuntimeFlags {
   embeddingApiBase?: string
 }
 
-export const flags: RuntimeFlags = {
+const DEFAULT_FLAGS: RuntimeFlags = {
   logLevel: LoggerLevel.Verbose,
   logFormat: LoggerFormat.Pretty,
 
   isDebugMode: false,
   isDatabaseDebugMode: false,
-
-  dbUrl: '',
 }
 
 const TRUE_VALUES: ReadonlySet<string> = new Set(['1', 'true', 'yes'])
@@ -67,68 +65,57 @@ function readIntegerEnv(key: string, env: Record<string, string | undefined>): n
   return undefined
 }
 
-export function parseEnvFlags(env: Record<string, string | undefined>): void {
+function assignIfPresent<T>(target: T, key: keyof T, value: T[keyof T] | undefined): void {
+  if (value !== undefined) {
+    target[key] = value
+  }
+}
+
+export function parseEnvFlags(env: Record<string, string | undefined>): RuntimeFlags {
+  const result: RuntimeFlags = { ...DEFAULT_FLAGS }
+
   const logLevelValue = readEnvValue('LOG_LEVEL', env)
   if (logLevelValue) {
     const normalized = logLevelValue.toLowerCase()
     switch (normalized) {
       case 'debug':
-        flags.logLevel = LoggerLevel.Debug
-        flags.isDebugMode = true
+        result.logLevel = LoggerLevel.Debug
+        result.isDebugMode = true
         break
       case 'verbose':
-        flags.logLevel = LoggerLevel.Verbose
-        flags.isDebugMode = false
+        result.logLevel = LoggerLevel.Verbose
+        result.isDebugMode = false
         break
     }
   }
 
-  flags.isDatabaseDebugMode = readBooleanEnv('DATABASE_DEBUG', env)
+  result.isDatabaseDebugMode = readBooleanEnv('DATABASE_DEBUG', env)
 
-  const dbUrlValue = readEnvValue('DATABASE_URL', env)
-  if (dbUrlValue) {
-    flags.dbUrl = dbUrlValue
-  }
-
-  const telegramId = readEnvValue('TELEGRAM_API_ID', env)
-  if (telegramId) {
-    flags.telegramApiId = telegramId
-  }
-
-  const telegramHash = readEnvValue('TELEGRAM_API_HASH', env)
-  if (telegramHash) {
-    flags.telegramApiHash = telegramHash
-  }
+  assignIfPresent(result, 'dbUrl', readEnvValue('DATABASE_URL', env))
+  assignIfPresent(result, 'telegramApiId', readEnvValue('TELEGRAM_API_ID', env))
+  assignIfPresent(result, 'telegramApiHash', readEnvValue('TELEGRAM_API_HASH', env))
 
   const embeddingProviderValue = readEnvValue('EMBEDDING_PROVIDER', env)
   if (embeddingProviderValue) {
     const normalized = embeddingProviderValue.toLowerCase()
     const provider = EMBEDDING_PROVIDER_ALIASES[normalized]
     if (provider) {
-      flags.embeddingProvider = provider
+      result.embeddingProvider = provider
     }
   }
 
-  const embeddingModelValue = readEnvValue('EMBEDDING_MODEL', env)
-  if (embeddingModelValue) {
-    flags.embeddingModel = embeddingModelValue
-  }
+  assignIfPresent(result, 'embeddingModel', readEnvValue('EMBEDDING_MODEL', env))
 
   const embeddingDimensionValue = readIntegerEnv('EMBEDDING_DIMENSION', env)
   if (
     typeof embeddingDimensionValue === 'number'
     && Object.values(EmbeddingDimension).includes(embeddingDimensionValue as EmbeddingDimension)
   ) {
-    flags.embeddingDimension = embeddingDimensionValue
+    result.embeddingDimension = embeddingDimensionValue
   }
 
-  const embeddingKeyValue = readEnvValue('EMBEDDING_API_KEY', env)
-  if (embeddingKeyValue) {
-    flags.embeddingApiKey = embeddingKeyValue
-  }
+  assignIfPresent(result, 'embeddingApiKey', readEnvValue('EMBEDDING_API_KEY', env))
+  assignIfPresent(result, 'embeddingApiBase', readEnvValue('EMBEDDING_BASE_URL', env))
 
-  const embeddingBaseValue = readEnvValue('EMBEDDING_BASE_URL', env)
-  if (embeddingBaseValue) {
-    flags.embeddingApiBase = embeddingBaseValue
-  }
+  return result
 }

--- a/packages/common/src/node/path.ts
+++ b/packages/common/src/node/path.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { useLogger } from '@unbird/logg'
 import { dirname, resolve } from 'pathe'
 
-import { DatabaseType, generateDefaultConfig } from '../config-schema'
+import { DatabaseType } from '../config-schema'
 
 const logger = useLogger()
 
@@ -42,7 +42,7 @@ export async function useConfigPath(): Promise<string> {
 
   if (!fs.existsSync(configPath)) {
     fs.mkdirSync(dirname(configPath), { recursive: true })
-    fs.writeFileSync(configPath, JSON.stringify(generateDefaultConfig()))
+    fs.copyFileSync(resolve(dirname(configPath), 'config.example.yaml'), configPath)
   }
 
   return configPath

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -13,7 +13,15 @@ export type CoreDB = PostgresDB | PgliteDB
 let dbInstance: CoreDB
 
 // TODO: options? here should contain dbPath, config.
-export async function initDrizzle(logger: Logger, config: Config, dbPath?: string, options?: { debuggerWebSocketUrl?: string }) {
+export async function initDrizzle(
+  logger: Logger,
+  config: Config,
+  options?: {
+    dbPath?: string
+    debuggerWebSocketUrl?: string
+    isDatabaseDebugMode?: boolean
+  },
+) {
   logger.log('Initializing database...')
 
   // Get configuration
@@ -23,18 +31,24 @@ export async function initDrizzle(logger: Logger, config: Config, dbPath?: strin
   switch (dbType) {
     case DatabaseType.POSTGRES: {
       const { initPgDrizzle } = await import('./pg')
-      dbInstance = await initPgDrizzle(logger, config)
+      dbInstance = await initPgDrizzle(logger, config, {
+        isDatabaseDebugMode: options?.isDatabaseDebugMode,
+      })
       break
     }
 
     case DatabaseType.PGLITE: {
       if (isBrowser()) {
         const { initPgliteDrizzleInBrowser } = await import('./pglite.browser')
-        dbInstance = await initPgliteDrizzleInBrowser(logger, options)
+        dbInstance = await initPgliteDrizzleInBrowser(logger, {
+          isDatabaseDebugMode: options?.isDatabaseDebugMode,
+        })
       }
       else {
         const { initPgliteDrizzleInNode } = await import('./pglite')
-        dbInstance = await initPgliteDrizzleInNode(logger, config, dbPath)
+        dbInstance = await initPgliteDrizzleInNode(logger, config, dbPath, {
+          isDatabaseDebugMode: options?.isDatabaseDebugMode,
+        })
       }
       break
     }

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -46,7 +46,7 @@ export async function initDrizzle(
       }
       else {
         const { initPgliteDrizzleInNode } = await import('./pglite')
-        dbInstance = await initPgliteDrizzleInNode(logger, config, dbPath, {
+        dbInstance = await initPgliteDrizzleInNode(logger, config, options?.dbPath, {
           isDatabaseDebugMode: options?.isDatabaseDebugMode,
         })
       }

--- a/packages/core/src/db/pg.ts
+++ b/packages/core/src/db/pg.ts
@@ -21,7 +21,13 @@ async function applyMigrations(logger: Logger, db: PostgresDB) {
   }
 }
 
-export async function initPgDrizzle(logger: Logger, config: Config) {
+export async function initPgDrizzle(
+  logger: Logger,
+  config: Config,
+  options: {
+    isDatabaseDebugMode?: boolean
+  } = {},
+) {
   logger.log('Initializing database...')
 
   // Initialize PostgreSQL database
@@ -35,7 +41,7 @@ export async function initPgDrizzle(logger: Logger, config: Config) {
     },
   })
 
-  const db = drizzle(client, { logger: flags.isDatabaseDebugMode }) as PostgresDB
+  const db = drizzle(client, { logger: options.isDatabaseDebugMode }) as PostgresDB
 
   // Check database connection
   try {

--- a/packages/core/src/db/pg.ts
+++ b/packages/core/src/db/pg.ts
@@ -3,7 +3,7 @@ import type { Logger } from '@unbird/logg'
 import type { drizzle as drizzlePg } from 'drizzle-orm/postgres-js'
 
 import { migrate as migratePg } from '@proj-airi/drizzle-orm-browser-migrator/pg'
-import { flags, getDatabaseDSN } from '@tg-search/common'
+import { getDatabaseDSN } from '@tg-search/common'
 import { sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
@@ -41,7 +41,7 @@ export async function initPgDrizzle(
     },
   })
 
-  const db = drizzle(client, { logger: options.isDatabaseDebugMode }) as PostgresDB
+  const db = drizzle(client, { logger: !!options.isDatabaseDebugMode }) as PostgresDB
 
   // Check database connection
   try {

--- a/packages/core/src/db/pglite.browser.ts
+++ b/packages/core/src/db/pglite.browser.ts
@@ -5,7 +5,6 @@ import type { drizzle as drizzlePglite } from 'drizzle-orm/pglite'
 import { IdbFs, PGlite } from '@electric-sql/pglite'
 import { vector } from '@electric-sql/pglite/vector'
 import { migrate } from '@proj-airi/drizzle-orm-browser-migrator/pglite'
-import { flags } from '@tg-search/common'
 import { defineInvokeEventa, defineInvokeHandler } from '@unbird/eventa'
 import { createContext } from '@unbird/eventa/adapters/websocket/native'
 import { sql } from 'drizzle-orm'
@@ -26,7 +25,13 @@ async function applyMigrations(logger: Logger, db: PgliteDB) {
   }
 }
 
-export async function initPgliteDrizzleInBrowser(logger: Logger, options?: { debuggerWebSocketUrl?: string }) {
+export async function initPgliteDrizzleInBrowser(
+  logger: Logger,
+  options: {
+    debuggerWebSocketUrl?: string
+    isDatabaseDebugMode?: boolean
+  } = {},
+) {
   logger.log('Initializing database...')
 
   try {
@@ -54,7 +59,7 @@ export async function initPgliteDrizzleInBrowser(logger: Logger, options?: { deb
     }
 
     // Create Drizzle instance
-    const db = drizzle(pglite, { logger: flags.isDatabaseDebugMode }) as PgliteDB
+    const db = drizzle(pglite, { logger: options.isDatabaseDebugMode }) as PgliteDB
 
     // Check database connection
     try {

--- a/packages/core/src/db/pglite.browser.ts
+++ b/packages/core/src/db/pglite.browser.ts
@@ -59,7 +59,7 @@ export async function initPgliteDrizzleInBrowser(
     }
 
     // Create Drizzle instance
-    const db = drizzle(pglite, { logger: options.isDatabaseDebugMode }) as PgliteDB
+    const db = drizzle(pglite, { logger: !!options.isDatabaseDebugMode }) as PgliteDB
 
     // Check database connection
     try {

--- a/packages/core/src/db/pglite.ts
+++ b/packages/core/src/db/pglite.ts
@@ -7,7 +7,6 @@ import fs from 'node:fs'
 import { PGlite } from '@electric-sql/pglite'
 import { vector } from '@electric-sql/pglite/vector'
 import { migrate } from '@proj-airi/drizzle-orm-browser-migrator/pglite'
-import { flags } from '@tg-search/common'
 import { getDatabaseFilePath } from '@tg-search/common/node'
 import { sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/pglite'
@@ -26,7 +25,14 @@ async function applyMigrations(logger: Logger, db: PgliteDB) {
   }
 }
 
-export async function initPgliteDrizzleInNode(logger: Logger, config: Config, dbPath?: string) {
+export async function initPgliteDrizzleInNode(
+  logger: Logger,
+  config: Config,
+  dbPath?: string,
+  options: {
+    isDatabaseDebugMode?: boolean
+  } = {},
+) {
   logger.log('Initializing database...')
 
   try {
@@ -38,7 +44,7 @@ export async function initPgliteDrizzleInNode(logger: Logger, config: Config, db
     })
 
     // Create Drizzle instance
-    const db = drizzle(pglite, { logger: flags.isDatabaseDebugMode }) as PgliteDB
+    const db = drizzle(pglite, { logger: options.isDatabaseDebugMode }) as PgliteDB
 
     // Check database connection
     try {

--- a/packages/core/src/db/pglite.ts
+++ b/packages/core/src/db/pglite.ts
@@ -44,7 +44,7 @@ export async function initPgliteDrizzleInNode(
     })
 
     // Create Drizzle instance
-    const db = drizzle(pglite, { logger: options.isDatabaseDebugMode }) as PgliteDB
+    const db = drizzle(pglite, { logger: !!options.isDatabaseDebugMode }) as PgliteDB
 
     // Check database connection
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2914,26 +2914,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.21':
-    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
-
   '@vue/compiler-core@3.5.22':
     resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
-
-  '@vue/compiler-dom@3.5.21':
-    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
 
   '@vue/compiler-dom@3.5.22':
     resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
 
-  '@vue/compiler-sfc@3.5.21':
-    resolution: {integrity: sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==}
-
   '@vue/compiler-sfc@3.5.22':
     resolution: {integrity: sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==}
-
-  '@vue/compiler-ssr@3.5.21':
-    resolution: {integrity: sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==}
 
   '@vue/compiler-ssr@3.5.22':
     resolution: {integrity: sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==}
@@ -2977,14 +2965,6 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.0.7':
-    resolution: {integrity: sha512-0sqqyqJ0Gn33JH3TdIsZLCZZ8Gr4kwlg8iYOnOrDDkJKSjFurlQY/bEFQx5zs7SX2C/bjMkmPYq/NiyY1fTOkw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@vue/language-core@3.0.8':
     resolution: {integrity: sha512-eYs6PF7bxoPYvek9qxceo1BCwFbJZYqJll+WaYC8o8ec60exqj+n+QRGGiJHSeUfYp0hDxARbMdxMq/fbPgU5g==}
     peerDependencies:
@@ -3006,9 +2986,6 @@ packages:
     resolution: {integrity: sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==}
     peerDependencies:
       vue: 3.5.22
-
-  '@vue/shared@3.5.21':
-    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
 
   '@vue/shared@3.5.22':
     resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
@@ -3669,15 +3646,6 @@ packages:
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -5302,9 +5270,6 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
-
-  mlly@1.7.4:
-    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -7424,7 +7389,7 @@ snapshots:
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.4
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7588,7 +7553,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7601,7 +7566,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7927,7 +7892,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7941,7 +7906,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -8028,11 +7993,11 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 9.2.0
       '@iconify/types': 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.2
-      mlly: 1.7.4
+      mlly: 1.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8102,7 +8067,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8450,7 +8415,7 @@ snapshots:
       jiti: 2.5.1
       klona: 2.0.6
       knitwork: 1.2.0
-      mlly: 1.7.4
+      mlly: 1.8.0
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -8476,7 +8441,7 @@ snapshots:
       ignore: 7.0.5
       jiti: 2.5.1
       klona: 2.0.6
-      mlly: 1.7.4
+      mlly: 1.8.0
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -8493,7 +8458,7 @@ snapshots:
 
   '@nuxt/schema@4.0.3':
     dependencies:
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       consola: 3.4.2
       defu: 6.1.4
       pathe: 2.0.3
@@ -8535,7 +8500,7 @@ snapshots:
       jiti: 2.5.1
       knitwork: 1.2.0
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       mocked-exports: 0.1.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -8592,7 +8557,7 @@ snapshots:
       jiti: 2.5.1
       knitwork: 1.2.0
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       mocked-exports: 0.1.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -9159,7 +9124,7 @@ snapshots:
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       fflate: 0.8.2
       token-types: 6.0.3
     transitivePeerDependencies:
@@ -9261,7 +9226,7 @@ snapshots:
       '@typescript-eslint/types': 8.40.0
       '@typescript-eslint/typescript-estree': 8.40.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.40.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.36.0(jiti@2.5.1)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -9271,7 +9236,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.44.0
-      debug: 4.4.1
+      debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -9280,7 +9245,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.44.0
-      debug: 4.4.1
+      debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -9308,7 +9273,7 @@ snapshots:
       '@typescript-eslint/types': 8.40.0
       '@typescript-eslint/typescript-estree': 8.40.0(typescript@5.9.2)
       '@typescript-eslint/utils': 8.40.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.36.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -9325,7 +9290,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.40.0
       '@typescript-eslint/visitor-keys': 8.40.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -9341,7 +9306,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/visitor-keys': 8.44.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -9743,7 +9708,7 @@ snapshots:
   '@vue-macros/boolean-prop@0.5.5(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-core': 3.5.21
+      '@vue/compiler-core': 3.5.22
     transitivePeerDependencies:
       - vue
 
@@ -9763,7 +9728,7 @@ snapshots:
 
   '@vue-macros/common@1.16.1(vue@3.5.22(typescript@5.9.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
       ast-kit: 1.4.3
       local-pkg: 1.1.2
       magic-string-ast: 0.7.1
@@ -9774,7 +9739,7 @@ snapshots:
 
   '@vue-macros/common@3.0.0-beta.16(vue@3.5.22(typescript@5.9.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
       ast-kit: 2.1.2
       local-pkg: 1.1.2
       magic-string-ast: 1.0.2
@@ -9859,7 +9824,7 @@ snapshots:
   '@vue-macros/define-stylex@0.2.3(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
@@ -9885,7 +9850,7 @@ snapshots:
   '@vue-macros/export-expose@0.3.5(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
       unplugin: 1.16.1
       vue: 3.5.22(typescript@5.9.2)
 
@@ -9911,7 +9876,7 @@ snapshots:
   '@vue-macros/jsx-directive@0.10.6(typescript@5.9.2)':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
       unplugin: 1.16.1
       vue: 3.5.22(typescript@5.9.2)
     transitivePeerDependencies:
@@ -9920,7 +9885,7 @@ snapshots:
   '@vue-macros/named-template@0.5.5(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
@@ -9929,8 +9894,8 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.4
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-core': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-core': 3.5.22
+      '@vue/shared': 3.5.22
       magic-string: 0.30.19
       unplugin: 1.16.1
       vue: 3.5.22(typescript@5.9.2)
@@ -9944,7 +9909,7 @@ snapshots:
   '@vue-macros/setup-block@0.4.5(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
@@ -9966,7 +9931,7 @@ snapshots:
   '@vue-macros/short-bind@1.1.5(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-core': 3.5.21
+      '@vue/compiler-core': 3.5.22
     transitivePeerDependencies:
       - vue
 
@@ -9987,7 +9952,7 @@ snapshots:
   '@vue-macros/short-vmodel@1.5.5(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 1.16.1(vue@3.5.22(typescript@5.9.2))
-      '@vue/compiler-core': 3.5.21
+      '@vue/compiler-core': 3.5.22
     transitivePeerDependencies:
       - vue
 
@@ -10043,7 +10008,7 @@ snapshots:
       '@babel/types': 7.28.4
       '@vue/babel-helper-vue-transform-on': 1.4.0
       '@vue/babel-plugin-resolve-type': 1.4.0(@babel/core@7.28.0)
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
     optionalDependencies:
       '@babel/core': 7.28.0
     transitivePeerDependencies:
@@ -10056,17 +10021,9 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/parser': 7.28.4
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
     transitivePeerDependencies:
       - supports-color
-
-  '@vue/compiler-core@3.5.21':
-    dependencies:
-      '@babel/parser': 7.28.4
-      '@vue/shared': 3.5.21
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.22':
     dependencies:
@@ -10076,27 +10033,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.21':
-    dependencies:
-      '@vue/compiler-core': 3.5.21
-      '@vue/shared': 3.5.21
-
   '@vue/compiler-dom@3.5.22':
     dependencies:
       '@vue/compiler-core': 3.5.22
       '@vue/shared': 3.5.22
-
-  '@vue/compiler-sfc@3.5.21':
-    dependencies:
-      '@babel/parser': 7.28.4
-      '@vue/compiler-core': 3.5.21
-      '@vue/compiler-dom': 3.5.21
-      '@vue/compiler-ssr': 3.5.21
-      '@vue/shared': 3.5.21
-      estree-walker: 2.0.2
-      magic-string: 0.30.19
-      postcss: 8.5.6
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.22':
     dependencies:
@@ -10109,11 +10049,6 @@ snapshots:
       magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
-
-  '@vue/compiler-ssr@3.5.21':
-    dependencies:
-      '@vue/compiler-dom': 3.5.21
-      '@vue/shared': 3.5.21
 
   '@vue/compiler-ssr@3.5.22':
     dependencies:
@@ -10210,9 +10145,9 @@ snapshots:
   '@vue/language-core@2.1.10(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       alien-signals: 0.2.2
       minimatch: 9.0.5
       muggle-string: 0.4.1
@@ -10220,23 +10155,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@vue/language-core@3.0.7(typescript@5.9.2)':
-    dependencies:
-      '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.21
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.21
-      alien-signals: 2.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-      picomatch: 4.0.3
-    optionalDependencies:
-      typescript: 5.9.2
-
   '@vue/language-core@3.0.8(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.22
       alien-signals: 2.0.5
@@ -10267,8 +10189,6 @@ snapshots:
       '@vue/compiler-ssr': 3.5.22
       '@vue/shared': 3.5.22
       vue: 3.5.22(typescript@5.9.2)
-
-  '@vue/shared@3.5.21': {}
 
   '@vue/shared@3.5.22': {}
 
@@ -11011,10 +10931,6 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -11104,7 +11020,7 @@ snapshots:
   detective-vue2@2.2.0(typescript@5.9.2):
     dependencies:
       '@dependents/detective-less': 5.0.1
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
       detective-es6: 5.0.1
       detective-sass: 6.0.1
       detective-scss: 5.0.1
@@ -11266,7 +11182,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       esbuild: 0.25.9
     transitivePeerDependencies:
       - supports-color
@@ -11429,7 +11345,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint: 9.36.0(jiti@2.5.1)
       espree: 10.4.0
@@ -11504,7 +11420,7 @@ snapshots:
 
   eslint-plugin-toml@0.12.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.36.0(jiti@2.5.1)
       eslint-compat-utils: 0.6.5(eslint@9.36.0(jiti@2.5.1))
       lodash: 4.17.21
@@ -11555,7 +11471,7 @@ snapshots:
 
   eslint-plugin-yml@1.18.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint: 9.36.0(jiti@2.5.1)
       eslint-compat-utils: 0.6.5(eslint@9.36.0(jiti@2.5.1))
@@ -11602,7 +11518,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -11718,7 +11634,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -12014,7 +11930,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12064,7 +11980,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.3.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.1
+      debug: 4.4.3
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -12326,7 +12242,7 @@ snapshots:
       h3: 1.15.4
       http-shutdown: 1.2.2
       jiti: 2.5.1
-      mlly: 1.7.4
+      mlly: 1.8.0
       node-forge: 1.3.1
       pathe: 1.1.2
       std-env: 3.9.0
@@ -12339,7 +12255,7 @@ snapshots:
 
   local-pkg@1.1.2:
     dependencies:
-      mlly: 1.7.4
+      mlly: 1.8.0
       pkg-types: 2.3.0
       quansync: 0.2.11
 
@@ -12394,7 +12310,7 @@ snapshots:
     dependencies:
       estree-walker: 3.0.3
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       regexp-tree: 0.1.27
       type-level-regexp: 0.1.17
       ufo: 1.6.1
@@ -12730,7 +12646,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -12801,13 +12717,6 @@ snapshots:
   mitt@3.0.1: {}
 
   mkdirp@3.0.1: {}
-
-  mlly@1.7.4:
-    dependencies:
-      acorn: 8.15.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.1
 
   mlly@1.8.0:
     dependencies:
@@ -12898,7 +12807,7 @@ snapshots:
       magic-string: 0.30.19
       magicast: 0.3.5
       mime: 4.0.7
-      mlly: 1.7.4
+      mlly: 1.8.0
       node-fetch-native: 1.6.7
       node-mock-http: 1.0.2
       ofetch: 1.4.1
@@ -13031,7 +12940,7 @@ snapshots:
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
       '@nuxt/vite-builder': 4.0.3(@types/node@24.5.2)(eslint@9.36.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.40)(rollup@4.52.3)(terser@5.43.1)(tsx@4.20.6)(typescript@5.9.2)(vue@3.5.22(typescript@5.9.2))(yaml@2.8.1)
       '@unhead/vue': 2.0.14(vue@3.5.22(typescript@5.9.2))
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       c12: 3.2.0(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
@@ -13053,7 +12962,7 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.2.0
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       mocked-exports: 0.1.1
       nanotar: 0.2.0
       nitropack: 2.12.4(@electric-sql/pglite@0.3.10)(@netlify/blobs@9.1.2)(drizzle-orm@0.44.5(@electric-sql/pglite@0.3.10)(@types/pg@8.15.5)(pg@8.16.3)(postgres@3.4.7))(encoding@0.1.13)(rolldown@1.0.0-beta.40)
@@ -13155,7 +13064,7 @@ snapshots:
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
       '@nuxt/vite-builder': 4.0.3(@types/node@24.5.2)(eslint@9.36.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.3)(terser@5.43.1)(tsx@4.20.6)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2))(vue@3.5.22(typescript@5.9.2))(yaml@2.8.1)
       '@unhead/vue': 2.0.14(vue@3.5.22(typescript@5.9.2))
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       c12: 3.2.0(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
@@ -13177,7 +13086,7 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.2.0
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       mocked-exports: 0.1.1
       nanotar: 0.2.0
       nitropack: 2.12.4(@electric-sql/pglite@0.3.10)(@netlify/blobs@9.1.2)(drizzle-orm@0.44.5(@electric-sql/pglite@0.3.10)(@types/pg@8.15.5)(pg@8.16.3)(postgres@3.4.7))(encoding@0.1.13)(rolldown@1.0.0-beta.40)
@@ -13279,7 +13188,7 @@ snapshots:
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
       '@nuxt/vite-builder': 4.0.3(@types/node@24.5.2)(eslint@9.36.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.3)(terser@5.43.1)(tsx@4.20.6)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2))(vue@3.5.22(typescript@5.9.2))(yaml@2.8.1)
       '@unhead/vue': 2.0.14(vue@3.5.22(typescript@5.9.2))
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       c12: 3.2.0(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
@@ -13301,7 +13210,7 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.2.0
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       mocked-exports: 0.1.1
       nanotar: 0.2.0
       nitropack: 2.12.4(@electric-sql/pglite@0.3.10)(@netlify/blobs@9.1.2)(drizzle-orm@0.44.5(@electric-sql/pglite@0.3.10)(@types/pg@8.15.5)(pg@8.16.3)(postgres@3.4.7))(encoding@0.1.13)(rolldown@1.0.0-beta.40)
@@ -13684,7 +13593,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.7.4
+      mlly: 1.8.0
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -14236,7 +14145,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -14313,7 +14222,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14760,7 +14669,7 @@ snapshots:
       estree-walker: 3.0.3
       local-pkg: 1.1.2
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       pathe: 2.0.3
       picomatch: 4.0.3
       pkg-types: 2.3.0
@@ -15012,13 +14921,13 @@ snapshots:
     dependencies:
       '@vue-macros/common': 3.0.0-beta.16(vue@3.5.22(typescript@5.9.2))
       '@vue/compiler-sfc': 3.5.22
-      '@vue/language-core': 3.0.7(typescript@5.9.2)
+      '@vue/language-core': 3.0.8(typescript@5.9.2)
       ast-walker-scope: 0.8.1
       chokidar: 4.0.3
       json5: 2.2.3
       local-pkg: 1.1.2
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       muggle-string: 0.4.1
       pathe: 2.0.3
       picomatch: 4.0.3
@@ -15078,7 +14987,7 @@ snapshots:
     dependencies:
       knitwork: 1.2.0
       magic-string: 0.30.19
-      mlly: 1.7.4
+      mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
       unplugin: 2.3.10
@@ -15141,7 +15050,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -15180,7 +15089,7 @@ snapshots:
   vite-plugin-inspect@11.3.3(@nuxt/kit@3.18.1(magicast@0.3.5))(rolldown-vite@7.1.13(@types/node@24.5.2)(esbuild@0.25.9)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       ansis: 4.1.0
-      debug: 4.4.1
+      debug: 4.4.3
       error-stack-parser-es: 1.0.5
       ohash: 2.0.11
       open: 10.2.0
@@ -15197,7 +15106,7 @@ snapshots:
   vite-plugin-inspect@11.3.3(@nuxt/kit@3.18.1(magicast@0.3.5))(vite@7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       ansis: 4.1.0
-      debug: 4.4.1
+      debug: 4.4.3
       error-stack-parser-es: 1.0.5
       ohash: 2.0.11
       open: 10.2.0
@@ -15214,7 +15123,7 @@ snapshots:
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.0.3(magicast@0.3.5))(rolldown-vite@7.1.13(@types/node@24.5.2)(esbuild@0.25.9)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       ansis: 4.1.0
-      debug: 4.4.1
+      debug: 4.4.3
       error-stack-parser-es: 1.0.5
       ohash: 2.0.11
       open: 10.2.0
@@ -15266,7 +15175,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.0)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.28.0)
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       kolorist: 1.8.0
       magic-string: 0.30.19
       vite: rolldown-vite@7.1.13(@types/node@24.5.2)(esbuild@0.25.9)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -15281,7 +15190,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.0)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.28.0)
-      '@vue/compiler-dom': 3.5.21
+      '@vue/compiler-dom': 3.5.22
       kolorist: 1.8.0
       magic-string: 0.30.19
       vite: 7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -15290,7 +15199,7 @@ snapshots:
 
   vite-plugin-vue-layouts@0.11.0(rolldown-vite@7.1.13(@types/node@24.5.2)(esbuild@0.25.9)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.22(typescript@5.9.2)))(vue@3.5.22(typescript@5.9.2)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       vite: rolldown-vite@7.1.13(@types/node@24.5.2)(esbuild@0.25.9)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.2)
@@ -15300,7 +15209,7 @@ snapshots:
 
   vite-plugin-vue-layouts@0.11.0(vite@7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1))(vue-router@4.5.1(vue@3.5.22(typescript@5.9.2)))(vue@3.5.22(typescript@5.9.2)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       vite: 7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.2)
@@ -15356,7 +15265,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.1
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3
@@ -15401,7 +15310,7 @@ snapshots:
 
   vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.36.0(jiti@2.5.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1

--- a/scripts/db.ts
+++ b/scripts/db.ts
@@ -3,10 +3,11 @@ import process from 'node:process'
 
 import { useLogger } from '@unbird/logg'
 
-import { getDatabaseDSN, initConfig, useConfig } from '../packages/common/src'
+import { getDatabaseDSN, initConfig, parseEnvFlags, useConfig } from '../packages/common/src'
 
 (async () => {
-  await initConfig()
+  const flags = parseEnvFlags(process.env)
+  await initConfig(flags)
   const logger = useLogger('script:drizzle')
 
   const dsn = getDatabaseDSN(useConfig())


### PR DESCRIPTION
## Summary
- centralize runtime override generation and merge it with `defu` so env-provided Telegram and embedding values cleanly layer on top of config
- replace imperative env parsing with declarative parser definitions that normalize aliases for Telegram and embedding variables
- expose pgvector via optional `PGVECTOR_HOST_PORT`/`PGVECTOR_HOST_IP` in the main compose file and document the workflow across all READMEs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f5d2bc20832e80a1980bc505da3b