### PR TITLE
feat: display build version info in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 node_modules
 dist
+!packages/unplugin-info/dist/
 .env
 .session
 .DS_Store

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -35,6 +35,7 @@
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue-macros/volar": "^3.0.0-beta.23",
     "unocss": "^66.5.1",
+    "unplugin-info": "workspace:*",
     "unplugin-vue-macros": "^2.14.5",
     "unplugin-vue-router": "^0.15.0",
     "vite-plugin-inspect": "^11.3.3",

--- a/apps/frontend/src/env.d.ts
+++ b/apps/frontend/src/env.d.ts
@@ -1,0 +1,3 @@
+import type { Info } from 'unplugin-info/vite'
+
+declare const __UNPLUGIN_INFO__: Info

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import { env } from 'node:process'
 import DrizzleORMMigrations from '@proj-airi/unplugin-drizzle-orm-migrations/vite'
 import Vue from '@vitejs/plugin-vue'
 import UnoCSS from 'unocss/vite'
+import Info from 'unplugin-info/vite'
 import Unused from 'unplugin-unused/vite'
 import VueMacros from 'unplugin-vue-macros/vite'
 import VueRouter from 'unplugin-vue-router/vite'
@@ -14,6 +15,13 @@ import Layouts from 'vite-plugin-vue-layouts'
 
 export default defineConfig({
   plugins: [
+    Info({
+      rootDir: resolve(import.meta.dirname, '../..'),
+      packageJsonPath: resolve(import.meta.dirname, '../../package.json'),
+      additional: {
+        target: '@tg-search/frontend',
+      },
+    }),
     Inspect(),
 
     Unused({

--- a/packages/stage-ui/src/layouts/default.vue
+++ b/packages/stage-ui/src/layouts/default.vue
@@ -30,6 +30,29 @@ const { t } = useI18n()
 const settingsDialog = ref(false)
 const searchParams = ref('')
 
+const buildInfo = __UNPLUGIN_INFO__
+
+const buildVersionLabel = computed(() => {
+  const version = buildInfo.package.version ?? 'dev'
+  const commit = buildInfo.git.commitShortHash
+
+  return commit ? `${version} (${commit})` : version
+})
+
+const buildTimeLabel = computed(() => {
+  const iso = buildInfo.buildTime
+  const date = new Date(iso)
+
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date)
+})
+
 // Use VueUse breakpoints for responsive design
 const breakpoints = useBreakpoints(breakpointsTailwind)
 const isMobile = breakpoints.smaller('md') // < 768px
@@ -211,35 +234,45 @@ function closeMobileDrawer() {
       </div>
 
       <!-- User profile section -->
-      <div class="flex items-center justify-between border-t border-t-secondary p-4 dark:border-t-gray-700">
-        <div class="mr-3 flex items-center gap-3">
-          <div class="h-8 w-8 flex items-center justify-center overflow-hidden rounded-full bg-neutral-100 ring-2 ring-offset-1 ring-primary/10 dark:bg-gray-700">
-            <Avatar
-              :name="websocketStore.getActiveSession()?.me?.name"
-              size="sm"
-            />
+      <div class="flex flex-col gap-2 border-t border-t-secondary p-4 dark:border-t-gray-700">
+        <div class="flex items-center justify-between">
+          <div class="mr-3 flex items-center gap-3">
+            <div class="h-8 w-8 flex items-center justify-center overflow-hidden rounded-full bg-neutral-100 ring-2 ring-offset-1 ring-primary/10 dark:bg-gray-700">
+              <Avatar
+                :name="websocketStore.getActiveSession()?.me?.name"
+                size="sm"
+              />
+            </div>
+            <div class="flex flex-col">
+              <span class="whitespace-nowrap text-sm text-gray-900 font-medium dark:text-gray-100">{{ websocketStore.getActiveSession()?.me?.name }}</span>
+              <span class="whitespace-nowrap text-xs text-gray-600 dark:text-gray-400">{{ websocketStore.getActiveSession()?.isConnected ? t('settings.connected') : t('settings.disconnected') }}</span>
+            </div>
           </div>
-          <div class="flex flex-col">
-            <span class="whitespace-nowrap text-sm text-gray-900 font-medium dark:text-gray-100">{{ websocketStore.getActiveSession()?.me?.name }}</span>
-            <span class="whitespace-nowrap text-xs text-gray-600 dark:text-gray-400">{{ websocketStore.getActiveSession()?.isConnected ? t('settings.connected') : t('settings.disconnected') }}</span>
+
+          <!-- Control buttons -->
+          <div class="flex items-center gap-2">
+            <Button
+              :icon="isDark ? 'i-lucide-sun' : 'i-lucide-moon'"
+              class="h-8 w-8 flex items-center justify-center rounded-md p-1 text-gray-900 transition-colors hover:bg-neutral-100/80 dark:text-gray-100 dark:hover:bg-gray-700/70"
+              :title="isDark ? t('settings.switchToLightMode') : t('settings.switchToDarkMode')"
+              @click="() => { isDark = !isDark }"
+            />
+
+            <Button
+              icon="i-lucide-settings"
+              class="h-8 w-8 flex items-center justify-center rounded-md p-1 text-gray-900 transition-colors hover:bg-neutral-100/80 dark:text-gray-100 dark:hover:bg-gray-700/70"
+              :title="t('settings.settings')"
+              @click="toggleSettingsDialog"
+            />
           </div>
         </div>
 
-        <!-- Control buttons -->
-        <div class="flex items-center gap-2">
-          <Button
-            :icon="isDark ? 'i-lucide-sun' : 'i-lucide-moon'"
-            class="h-8 w-8 flex items-center justify-center rounded-md p-1 text-gray-900 transition-colors hover:bg-neutral-100/80 dark:text-gray-100 dark:hover:bg-gray-700/70"
-            :title="isDark ? t('settings.switchToLightMode') : t('settings.switchToDarkMode')"
-            @click="() => { isDark = !isDark }"
-          />
-
-          <Button
-            icon="i-lucide-settings"
-            class="h-8 w-8 flex items-center justify-center rounded-md p-1 text-gray-900 transition-colors hover:bg-neutral-100/80 dark:text-gray-100 dark:hover:bg-gray-700/70"
-            :title="t('settings.settings')"
-            @click="toggleSettingsDialog"
-          />
+        <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+          <span class="truncate">Build: {{ buildVersionLabel }}</span>
+          <span
+            v-if="buildTimeLabel"
+            class="truncate"
+          >{{ buildTimeLabel }}</span>
         </div>
       </div>
     </div>

--- a/packages/unplugin-info/dist/vite.d.ts
+++ b/packages/unplugin-info/dist/vite.d.ts
@@ -1,0 +1,32 @@
+import type { PluginOption } from 'vite'
+
+export interface GitInfo {
+  readonly branch: string | null
+  readonly commitHash: string | null
+  readonly commitShortHash: string | null
+  readonly commitTimestamp: number | null
+}
+
+export interface PackageInfo {
+  readonly name: string | null
+  readonly version: string | null
+}
+
+export interface BuildInfo {
+  readonly package: PackageInfo
+  readonly git: GitInfo
+  readonly buildTimestamp: number
+  readonly buildTime: string
+  readonly additional: Record<string, unknown>
+}
+
+export interface InfoPluginOptions {
+  readonly rootDir?: string
+  readonly packageJsonPath?: string
+  readonly defineName?: string
+  readonly additional?: Record<string, unknown>
+}
+
+export default function InfoPlugin(options?: InfoPluginOptions): PluginOption
+
+export type { BuildInfo as Info, InfoPluginOptions as InfoOptions }

--- a/packages/unplugin-info/dist/vite.mjs
+++ b/packages/unplugin-info/dist/vite.mjs
@@ -1,0 +1,77 @@
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+const DEFAULT_DEFINE_NAME = '__UNPLUGIN_INFO__'
+
+const safeExec = (command, cwd) => {
+  try {
+    return execSync(command, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim()
+  }
+  catch {
+    return null
+  }
+}
+
+const readPackageInfo = (packageJsonPath) => {
+  try {
+    const content = readFileSync(packageJsonPath, 'utf8')
+    const parsed = JSON.parse(content)
+    return {
+      name: parsed?.name ?? null,
+      version: parsed?.version ?? null,
+    }
+  }
+  catch {
+    return {
+      name: null,
+      version: null,
+    }
+  }
+}
+
+const collectBuildInfo = (options) => {
+  const cwd = options?.rootDir ?? process.cwd()
+  const packageJsonPath = options?.packageJsonPath ?? resolve(cwd, 'package.json')
+  const packageInfo = readPackageInfo(packageJsonPath)
+  const commitHash = safeExec('git rev-parse HEAD', cwd)
+  return {
+    package: packageInfo,
+    git: {
+      branch: safeExec('git rev-parse --abbrev-ref HEAD', cwd),
+      commitHash,
+      commitShortHash: commitHash ? safeExec('git rev-parse --short HEAD', cwd) : null,
+      commitTimestamp: commitHash ? Number.parseInt(safeExec('git show -s --format=%ct HEAD', cwd) ?? '', 10) || null : null,
+    },
+    buildTimestamp: Date.now(),
+    buildTime: new Date().toISOString(),
+    additional: { ...(options?.additional ?? {}) },
+  }
+}
+
+const InfoPlugin = (options = {}) => {
+  const defineName = options?.defineName ?? DEFAULT_DEFINE_NAME
+  let info = collectBuildInfo(options)
+  return {
+    name: 'unplugin-info',
+    enforce: 'pre',
+    config() {
+      info = collectBuildInfo(options)
+      return {
+        define: {
+          [defineName]: JSON.stringify(info),
+        },
+      }
+    },
+    handleHotUpdate() {
+      info = collectBuildInfo(options)
+    },
+  }
+}
+
+export { InfoPlugin as default }

--- a/packages/unplugin-info/package.json
+++ b/packages/unplugin-info/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "unplugin-info",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    "./vite": {
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.mjs"
+    }
+  }
+}

--- a/packages/unplugin-info/src/vite.ts
+++ b/packages/unplugin-info/src/vite.ts
@@ -1,0 +1,112 @@
+import type { PluginOption } from 'vite'
+
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+export interface GitInfo {
+  readonly branch: string | null
+  readonly commitHash: string | null
+  readonly commitShortHash: string | null
+  readonly commitTimestamp: number | null
+}
+
+export interface PackageInfo {
+  readonly name: string | null
+  readonly version: string | null
+}
+
+export interface BuildInfo {
+  readonly package: PackageInfo
+  readonly git: GitInfo
+  readonly buildTimestamp: number
+  readonly buildTime: string
+  readonly additional: Record<string, unknown>
+}
+
+export interface InfoPluginOptions {
+  readonly rootDir?: string
+  readonly packageJsonPath?: string
+  readonly defineName?: string
+  readonly additional?: Record<string, unknown>
+}
+
+const DEFAULT_DEFINE_NAME = '__UNPLUGIN_INFO__'
+
+function safeExec(command: string, cwd: string): string | null {
+  try {
+    return execSync(command, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim()
+  }
+  catch {
+    return null
+  }
+}
+
+function readPackageInfo(packageJsonPath: string): PackageInfo {
+  try {
+    const content = readFileSync(packageJsonPath, 'utf8')
+    const parsed = JSON.parse(content) as { name?: string, version?: string }
+
+    return {
+      name: parsed.name ?? null,
+      version: parsed.version ?? null,
+    }
+  }
+  catch {
+    return {
+      name: null,
+      version: null,
+    }
+  }
+}
+
+function collectBuildInfo(options: InfoPluginOptions): BuildInfo {
+  const cwd = options.rootDir ?? process.cwd()
+  const packageJsonPath = options.packageJsonPath ?? resolve(cwd, 'package.json')
+  const packageInfo = readPackageInfo(packageJsonPath)
+
+  const commitHash = safeExec('git rev-parse HEAD', cwd)
+  const info: BuildInfo = {
+    package: packageInfo,
+    git: {
+      branch: safeExec('git rev-parse --abbrev-ref HEAD', cwd),
+      commitHash,
+      commitShortHash: commitHash ? safeExec('git rev-parse --short HEAD', cwd) : null,
+      commitTimestamp: commitHash ? Number.parseInt(safeExec('git show -s --format=%ct HEAD', cwd) ?? '', 10) || null : null,
+    },
+    buildTimestamp: Date.now(),
+    buildTime: new Date().toISOString(),
+    additional: { ...options.additional },
+  }
+
+  return info
+}
+
+export default function InfoPlugin(options: InfoPluginOptions = {}): PluginOption {
+  const defineName = options.defineName ?? DEFAULT_DEFINE_NAME
+  let info = collectBuildInfo(options)
+
+  return {
+    name: 'unplugin-info',
+    enforce: 'pre',
+    config() {
+      info = collectBuildInfo(options)
+
+      return {
+        define: {
+          [defineName]: JSON.stringify(info),
+        },
+      }
+    },
+    handleHotUpdate() {
+      info = collectBuildInfo(options)
+    },
+  }
+}
+
+export type { BuildInfo as Info, InfoPluginOptions as InfoOptions }


### PR DESCRIPTION
## Summary
- add a local unplugin-info workspace package to inject build metadata during Vite runs
- wire the plugin into the frontend build, exposing __UNPLUGIN_INFO__ with package version and timestamps
- surface the build version and build time in the sidebar footer so the UI shows the current build details

## Testing
- pnpm lint
- pnpm -F @tg-search/frontend typecheck
- pnpm -F @tg-search/frontend build *(fails to download Roboto font because the CI environment blocks outbound network access; build output is still generated)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f8d7deb8832ea4dc7aa2a8c73dcd