### PR TITLE
refactor(web): render splash with vue and unocss

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,11 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <title>Telegram Search</title>
     <meta name="description" content="Telegram Search" />
   </head>
-  <body class="font-sans dark:text-white dark:bg-hex-121212">
+  <body class="font-sans bg-white text-slate-900 dark:bg-hex-121212 dark:text-slate-100">
     <div id="app"></div>
     <noscript>
       <div>Please enable JavaScript to use this application.</div>

--- a/apps/web/src/components/SplashScreen.vue
+++ b/apps/web/src/components/SplashScreen.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { ComputedRef, StyleValue } from 'vue'
+
+import { usePreferredReducedMotion } from '@vueuse/core'
+import { computed, ref } from 'vue'
+
+const emit = defineEmits<{
+  (event: 'after-leave'): void
+}>()
+
+const isVisible = ref(true)
+
+const reducedMotion = usePreferredReducedMotion()
+
+const spinnerClass: ComputedRef<string> = computed(() =>
+  reducedMotion.value ? '' : 'animate-spin',
+)
+
+const spinnerStyle: ComputedRef<StyleValue | undefined> = computed(() =>
+  reducedMotion.value ? { animation: 'none' } : undefined,
+)
+
+const transitionClasses = 'transition-opacity duration-300 ease-in-out'
+
+function hide(): void {
+  if (!isVisible.value) {
+    return
+  }
+
+  isVisible.value = false
+}
+
+function handleAfterLeave(): void {
+  emit('after-leave')
+}
+
+defineExpose<{ hide: () => void }>({ hide })
+</script>
+
+<template>
+  <Transition
+    appear
+    :enter-active-class="transitionClasses"
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-100"
+    :leave-active-class="transitionClasses"
+    leave-from-class="opacity-100"
+    leave-to-class="opacity-0"
+    @after-leave="handleAfterLeave"
+  >
+    <div
+      v-if="isVisible"
+      class="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-4 bg-white text-slate-900 dark:bg-hex-121212 dark:text-slate-100"
+    >
+      <div
+        class="h-12 w-12 border-[3px] border-slate-300/60 border-t-sky-500 rounded-full animate-spin"
+        :class="spinnerClass"
+        :style="spinnerStyle"
+        aria-hidden="true"
+      />
+      <p role="status" aria-live="polite" class="text-base font-medium">
+        Telegram Search 正在加载…
+      </p>
+    </div>
+  </Transition>
+</template>

--- a/apps/web/src/composables/useSplashScreen.ts
+++ b/apps/web/src/composables/useSplashScreen.ts
@@ -1,0 +1,49 @@
+import type { ComponentPublicInstance, App as VueApp } from 'vue'
+
+import { createApp } from 'vue'
+
+import SplashScreen from '../components/SplashScreen.vue'
+
+interface SplashScreenExpose {
+  hide: () => void
+}
+
+type SplashScreenInstance = ComponentPublicInstance<Record<string, never>, SplashScreenExpose>
+
+interface SplashController {
+  hide: () => void
+}
+
+type MountSplashScreen = () => SplashController
+
+export const mountSplashScreen: MountSplashScreen = () => {
+  const container: HTMLDivElement = document.createElement('div')
+  document.body.appendChild(container)
+
+  let splashApp: VueApp<Element> | null = null
+
+  const handleAfterLeave = (): void => {
+    splashApp?.unmount()
+    container.remove()
+    splashApp = null
+  }
+
+  splashApp = createApp(SplashScreen, {
+    onAfterLeave: handleAfterLeave,
+  })
+
+  let isVisible = true
+
+  const instance = splashApp.mount(container) as SplashScreenInstance
+
+  const hide = (): void => {
+    if (!isVisible) {
+      return
+    }
+
+    isVisible = false
+    instance.hide()
+  }
+
+  return { hide }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,5 +1,6 @@
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import { VueQueryPlugin } from '@tanstack/vue-query'
+import { useTimeoutFn } from '@vueuse/core'
 import { createPinia } from 'pinia'
 import { setupLayouts } from 'virtual:generated-layouts'
 import { createApp } from 'vue'
@@ -8,12 +9,15 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { routes as generatedRoutes } from 'vue-router/auto-routes'
 
 import App from './App.vue'
+import { mountSplashScreen } from './composables/useSplashScreen'
 import { en, zhCN } from './locales'
 
 import '@unocss/reset/tailwind.css'
 import 'uno.css'
 import 'vue-sonner/style.css'
 import './styles/main.css'
+
+const splash = mountSplashScreen()
 
 const app = createApp(App)
 
@@ -47,3 +51,17 @@ app.use(VueQueryPlugin)
 app.use(pinia)
 app.use(autoAnimatePlugin)
 app.mount('#app')
+
+const { stop: stopFallback } = useTimeoutFn(() => {
+  splash.hide()
+}, 4000)
+
+router
+  .isReady()
+  .catch(() => {
+    // Keeping the splash visible is safer than flashing an error immediately.
+  })
+  .finally(() => {
+    stopFallback()
+    splash.hide()
+  })


### PR DESCRIPTION
## Summary
- replace the inline HTML splash with a Vue splash component that relies on UnoCSS utilities for styling and accessibility
- add a splash mounting composable that hides after router readiness with a VueUse timeout fallback to avoid it lingering

## Testing
- pnpm -C apps/web build *(fails: FetchError downloading Roboto from fonts.googleapis.com due to offline sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e21991efb8832e9be79648f6cebdc7